### PR TITLE
Move Docker CI image to boshcpi org

### DIFF
--- a/ci/docker/bosh-google-cpi-boshrelease/Dockerfile
+++ b/ci/docker/bosh-google-cpi-boshrelease/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:15.04
-MAINTAINER Ferran Rodenas <frodenas@gmail.com>
+MAINTAINER Evan Brown <evanbrown@google.com>
 
 # Update base image
 ENV LANG en_US.UTF-8

--- a/ci/tasks/build-candidate.yml
+++ b/ci/tasks/build-candidate.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/deploy-dummy.yml
+++ b/ci/tasks/deploy-dummy.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/promote-candidate.yml
+++ b/ci/tasks/promote-candidate.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/setup-infrastructure.yml
+++ b/ci/tasks/setup-infrastructure.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/teardown-director.yml
+++ b/ci/tasks/teardown-director.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/teardown-infrastructure.yml
+++ b/ci/tasks/teardown-infrastructure.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src

--- a/ci/tasks/unit-tests.yml
+++ b/ci/tasks/unit-tests.yml
@@ -3,7 +3,7 @@ platform: linux
 image_resource:
   type: docker-image
   source:
-    repository: frodenas/bosh-google-cpi-boshrelease
+    repository: boshcpi/gce-cpi-release
     tag: v1
 inputs:
   - name: bosh-cpi-src


### PR DESCRIPTION
`frodenas/bosh-google-cpi-boshrelease` moves to `boshcpi/gce-cpi-release` in this change. The Docker image is used in CI jobs. The `bosh-google-cpi-release` pipeline was run to green completion with these changes.