### PR TITLE
updated 'getting started' link

### DIFF
--- a/docs/deploy_concourse.md
+++ b/docs/deploy_concourse.md
@@ -63,4 +63,4 @@ $ bosh deployment concourse.yml
 $ bosh deploy
 ```
 
-* Follow the [Concourse Getting Started](http://concourse.ci/getting-started.html) guide.
+* Follow the [Concourse Getting Started](http://concourse.ci/using-concourse.html) guide.


### PR DESCRIPTION
The last link in the concourse guide was broken. Updated it to http://concourse.ci/using-concourse.html