### PR TITLE
Return logs in CPI response

### DIFF
--- a/src/bosh-google-cpi/api/dispatcher/json.go
+++ b/src/bosh-google-cpi/api/dispatcher/json.go
@@ -3,8 +3,6 @@ package dispatcher
 import (
 	"encoding/json"
 
-	boshlog "github.com/cloudfoundry/bosh-utils/logger"
-
 	bgcaction "bosh-google-cpi/action"
 	bgcapi "bosh-google-cpi/api"
 )
@@ -41,13 +39,13 @@ type ResponseError struct {
 type JSON struct {
 	actionFactory bgcaction.Factory
 	caller        Caller
-	logger        boshlog.Logger
+	logger        bgcapi.MultiLogger
 }
 
 func NewJSON(
 	actionFactory bgcaction.Factory,
 	caller Caller,
-	logger boshlog.Logger,
+	logger bgcapi.MultiLogger,
 ) JSON {
 	return JSON{
 		actionFactory: actionFactory,
@@ -105,6 +103,8 @@ func (c JSON) buildCloudError(err error) []byte {
 	respErr := Response{
 		Error: &ResponseError{},
 	}
+
+	respErr.Log = c.logger.LogBuff.String()
 
 	if typedErr, ok := err.(bgcapi.CloudError); ok {
 		respErr.Error.Type = typedErr.Type()

--- a/src/bosh-google-cpi/api/multilogger.go
+++ b/src/bosh-google-cpi/api/multilogger.go
@@ -1,0 +1,12 @@
+package api
+
+import (
+	"bytes"
+
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+)
+
+type MultiLogger struct {
+	boshlog.Logger
+	LogBuff *bytes.Buffer
+}

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -7,7 +7,35 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("VM", func() {
+var _ = FDescribe("VM", func() {
+	It("creates a VM with an invalid configuration and receives an error message with logs", func() {
+		request := fmt.Sprintf(`{
+			  "method": "create_vm",
+			  "arguments": [
+				"agent",
+				"%v",
+				{
+				  "machine_type": "n1-standard-error"
+				},
+				{
+				  "default": {
+					"type": "dynamic",
+					"cloud_properties": {
+					  "tags": ["integration-delete"],
+					  "network_name": "%v"
+					}
+				  }
+				},
+				[],
+				{}
+			  ]
+			}`, existingStemcell, networkName)
+		resp, err := execCPI(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.Error.Message).ToNot(BeEmpty())
+		Expect(resp.Log).To(BeEmpty())
+	})
+
 	It("executes the VM lifecycle", func() {
 		var vmCID string
 		By("creating a VM")
@@ -55,6 +83,7 @@ var _ = Describe("VM", func() {
 			  "arguments": ["%v"]
 			}`, vmCID)
 		assertSucceeds(request)
+
 	})
 
 	It("executes the VM lifecycle with disk attachment hints", func() {


### PR DESCRIPTION
This change wraps the BOSH logger to support writing log output to multiple
writers. In this implementation the writers are os.Stdout and a bytes.Buffer.
If the CPI returns an error, it will also inclue the logs contents from the
buffer in the response's log property.

[#116497573](https://www.pivotaltracker.com/story/show/116497573)