### PR TITLE
docs: Regionalize Terraform and deployment manifests

### DIFF
--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -1,6 +1,16 @@
+variable "region" {
+    type = "string"
+    default = "us-east1"
+}
+
+variable "zone" {
+    type = "string"
+    default = "us-east1-d"
+}
+
 provider "google" {
     project = "REPLACE-WITH-YOUR-GOOGLE-PROJECT-ID"
-    region = "us-east1"
+    region = "${var.region}"
 }
 
 resource "google_compute_network" "cf" {
@@ -8,8 +18,8 @@ resource "google_compute_network" "cf" {
 }
 
 // Subnet for the BOSH director
-resource "google_compute_subnetwork" "bosh-us-east1" {
-  name          = "bosh-us-east1"
+resource "google_compute_subnetwork" "bosh-subnet-1" {
+  name          = "bosh-${var.region}"
   ip_cidr_range = "10.0.0.0/24"
   network       = "${google_compute_network.cf.self_link}"
 }
@@ -55,7 +65,7 @@ resource "google_compute_firewall" "bosh-internal" {
 resource "google_compute_instance" "bosh-bastion" {
   name         = "bosh-bastion"
   machine_type = "n1-standard-1"
-  zone         = "us-east1-b"
+  zone         = "${var.zone}"
 
   tags = ["bosh-bastion", "bosh-internal"]
 
@@ -64,7 +74,7 @@ resource "google_compute_instance" "bosh-bastion" {
   }
 
   network_interface {
-    subnetwork = "${google_compute_subnetwork.bosh-us-east1.name}"
+    subnetwork = "${google_compute_subnetwork.bosh-subnet-1.name}"
     access_config {
       // Ephemeral IP
     }

--- a/docs/cloudfoundry/cloudfoundry.tf
+++ b/docs/cloudfoundry/cloudfoundry.tf
@@ -1,13 +1,13 @@
 // Subnet for the public Cloud Foundry components
-resource "google_compute_subnetwork" "cf-public-us-east1" {
-  name          = "cf-public-us-east1"
+resource "google_compute_subnetwork" "cf-public-subnet-1" {
+  name          = "cf-public-${var.region}"
   ip_cidr_range = "10.200.0.0/16"
   network       = "${google_compute_network.cf.self_link}"
 }
 
 // Subnet for the private Cloud Foundry components
-resource "google_compute_subnetwork" "cf-private-us-east1" {
-  name          = "cf-private-us-east1"
+resource "google_compute_subnetwork" "cf-private-subnet-1" {
+  name          = "cf-private-${var.region}"
   ip_cidr_range = "192.168.0.0/16"
   network       = "${google_compute_network.cf.self_link}"
 }

--- a/docs/cloudfoundry/cloudfoundry.yml
+++ b/docs/cloudfoundry/cloudfoundry.yml
@@ -8,7 +8,7 @@ common_password = "c1oudc0w"
 deployment_name = "cf"
 
 # Google network settings
-google_region = "us-east1"
+google_region = "{{REGION}}"
 network = "cf"
 public_subnetwork = "cf-public-#{google_region}"
 private_subnetwork = "cf-private-#{google_region}"


### PR DESCRIPTION
IaaS configuration with Terraform supports apply-time region and zone specification.

Default region is `us-east1` and default zone is `us-east1-d`