### PR TITLE
Terraform startup script fails if end of line characters aren't Unix

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 config/*.yml -whitespace
+docs/*.tf eol=lf
 releases/*.yml -whitespace

--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -85,7 +85,7 @@ resource "google_compute_instance" "bosh-bastion" {
 apt-get update -y
 apt-get upgrade -y
 apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
-gem install bosh_cli 
+gem install bosh_cli
 curl -o /tmp/cf.tgz https://s3.amazonaws.com/go-cli/releases/v6.19.0/cf-cli_6.19.0_linux_x86-64.tgz
 tar -zxvf /tmp/cf.tgz && mv cf /usr/bin/cf && chmod +x /usr/bin/cf
 curl -o /usr/bin/bosh-init https://s3.amazonaws.com/bosh-init-artifacts/bosh-init-0.0.94-linux-amd64


### PR DESCRIPTION
The startup script requires unix end of line characters, so Terraform files that contain startup scripts require unix end of line characters. This is an attempt to fix #28.

This could be changed to just set the attributes of `docs\bosh\main.tf`.