### PR TITLE
all: Normalize cloud_provider options for bosh-init

### DIFF
--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -200,12 +200,6 @@ jobs:
 
       agent:
         mbus: nats://nats:nats-password@${google_address_static_director}:4222
-        ntp: *ntp
-        blobstore:
-           options:
-             endpoint: http://${google_address_static_director}:25250
-             user: agent
-             password: agent-password
 
       ntp: &ntp
         - 169.254.169.254
@@ -227,11 +221,11 @@ cloud_provider:
     google: *google_properties
     agent:
       mbus: https://mbus:mbus-password@0.0.0.0:6868
-      blobstore:
-        provider: local
-        options:
-          blobstore_path: /var/vcap/micro_bosh/data/cache
-      ntp: *ntp
+    blobstore:
+      provider: local
+      options:
+        blobstore_path: /var/vcap/micro_bosh/data/cache
+    ntp: *ntp
 EOF
 
 pushd ${deployment_dir}

--- a/jobs/google_cpi/spec
+++ b/jobs/google_cpi/spec
@@ -29,13 +29,13 @@ properties:
 
   agent.mbus:
     description: "Mbus URL used by deployed BOSH agents"
-  agent.ntp:
+  ntp:
     description: "NTP configuration used by deployed BOSH agents"
     default: []
-  agent.blobstore.provider:
+  blobstore.provider:
     description: "Provider type for the blobstore used by deployed BOSH agents (e.g. dav, s3)"
     default: "dav"
-  agent.blobstore.options:
+  blobstore.options:
     description: "Options for the blobstore used by deployed BOSH agents"
     default: {}
 

--- a/jobs/google_cpi/templates/config/cpi.json.erb
+++ b/jobs/google_cpi/templates/config/cpi.json.erb
@@ -10,11 +10,11 @@ JSON.dump(
   "actions" => {
     "agent" => {
       "mbus" => p("agent.mbus"),
-      "ntp"  => p("agent.ntp"),
-      "blobstore" => {
-        "type"    => p("agent.blobstore.provider"),
-        "options" => p("agent.blobstore.options"),
-      },
+    },
+    "ntp"  => p("ntp"),
+    "blobstore" => {
+      "type"    => p("blobstore.provider"),
+      "options" => p("blobstore.options"),
     },
     "registry" => {
       "use_gce_metadata" => true,

--- a/src/bosh-google-cpi/action/concrete_factory.go
+++ b/src/bosh-google-cpi/action/concrete_factory.go
@@ -167,6 +167,8 @@ func NewConcreteFactory(
 				registryClient,
 				options.Registry,
 				options.Agent,
+				options.Blobstore,
+				options.Ntp,
 				googleClient.DefaultRootDiskSizeGb(),
 				googleClient.DefaultRootDiskType(),
 				googleClient.DefaultZone(),

--- a/src/bosh-google-cpi/action/concrete_factory_options.go
+++ b/src/bosh-google-cpi/action/concrete_factory_options.go
@@ -9,13 +9,22 @@ import (
 type ConcreteFactoryOptions struct {
 	Agent    registry.AgentOptions
 	Registry registry.ClientOptions
+
+	// List of NTP servers
+	Ntp []string
+
+	// Blobstore options
+	Blobstore registry.BlobstoreOptions
 }
 
 func (o ConcreteFactoryOptions) Validate() error {
 	if err := o.Agent.Validate(); err != nil {
 		return bosherr.WrapError(err, "Validating Agent configuration")
 	}
-
+	err := o.Blobstore.Validate()
+	if err != nil {
+		return bosherr.WrapError(err, "Validating Blobstore configuration")
+	}
 	if err := o.Registry.Validate(); err != nil {
 		return bosherr.WrapError(err, "Validating Registry configuration")
 	}

--- a/src/bosh-google-cpi/action/concrete_factory_options_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_options_test.go
@@ -16,10 +16,10 @@ var _ = Describe("ConcreteFactoryOptions", func() {
 		validOptions = ConcreteFactoryOptions{
 			Agent: registry.AgentOptions{
 				Mbus: "fake-mbus",
-				Ntp:  []string{},
-				Blobstore: registry.BlobstoreOptions{
-					Type: "fake-blobstore-type",
-				},
+			},
+			Ntp: []string{},
+			Blobstore: registry.BlobstoreOptions{
+				Type: "fake-blobstore-type",
 			},
 			Registry: registry.ClientOptions{
 				Protocol: "http",

--- a/src/bosh-google-cpi/action/concrete_factory_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_test.go
@@ -250,6 +250,8 @@ var _ = Describe("ConcreteFactory", func() {
 			registryClient,
 			options.Registry,
 			options.Agent,
+			options.Blobstore,
+			options.Ntp,
 			googleClient.DefaultRootDiskSizeGb(),
 			googleClient.DefaultRootDiskType(),
 			googleClient.DefaultZone(),

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -23,6 +23,8 @@ type CreateVM struct {
 	registryClient        registry.Client
 	registryOptions       registry.ClientOptions
 	agentOptions          registry.AgentOptions
+	blobstoreOptions      registry.BlobstoreOptions
+	ntp                   []string
 	defaultRootDiskSizeGb int
 	defaultRootDiskType   string
 	defaultZone           string
@@ -37,19 +39,23 @@ func NewCreateVM(
 	registryClient registry.Client,
 	registryOptions registry.ClientOptions,
 	agentOptions registry.AgentOptions,
+	blobstoreOptions registry.BlobstoreOptions,
+	ntp []string,
 	defaultRootDiskSizeGb int,
 	defaultRootDiskType string,
 	defaultZone string,
 ) CreateVM {
 	return CreateVM{
-		vmService:             vmService,
-		diskService:           diskService,
-		diskTypeService:       diskTypeService,
-		imageService:          imageService,
-		machineTypeService:    machineTypeService,
-		registryClient:        registryClient,
-		registryOptions:       registryOptions,
-		agentOptions:          agentOptions,
+		vmService:          vmService,
+		diskService:        diskService,
+		diskTypeService:    diskTypeService,
+		imageService:       imageService,
+		machineTypeService: machineTypeService,
+		registryClient:     registryClient,
+		registryOptions:    registryOptions,
+		agentOptions:       agentOptions,
+		blobstoreOptions:   blobstoreOptions,
+		ntp:                ntp,
 		defaultRootDiskSizeGb: defaultRootDiskSizeGb,
 		defaultRootDiskType:   defaultRootDiskType,
 		defaultZone:           defaultZone,
@@ -121,7 +127,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 
 	// Create VM settings
 	agentNetworks := networks.AsRegistryNetworks()
-	agentSettings := registry.NewAgentSettings(agentID, vm, agentNetworks, registry.EnvSettings(env), cv.agentOptions)
+	agentSettings := registry.NewAgentSettings(agentID, vm, agentNetworks, registry.EnvSettings(env), cv.agentOptions, cv.blobstoreOptions, cv.ntp)
 	if err = cv.registryClient.Update(vm, agentSettings); err != nil {
 		return "", bosherr.WrapErrorf(err, "Creating VM")
 	}

--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -38,6 +38,8 @@ var _ = Describe("CreateVM", func() {
 		defaultRootDiskType      string
 		registryOptions          registry.ClientOptions
 		agentOptions             registry.AgentOptions
+		blobstore                registry.BlobstoreOptions
+		ntp                      []string
 		expectedVMProps          *instance.Properties
 		expectedInstanceNetworks instance.Networks
 		expectedAgentSettings    registry.AgentSettings
@@ -68,9 +70,9 @@ var _ = Describe("CreateVM", func() {
 		}
 		agentOptions = registry.AgentOptions{
 			Mbus: "http://fake-mbus",
-			Blobstore: registry.BlobstoreOptions{
-				Type: "fake-blobstore-type",
-			},
+		}
+		blobstore = registry.BlobstoreOptions{
+			Type: "fake-blobstore-type",
 		}
 		defaultRootDiskSizeGb = 0
 		defaultRootDiskType = ""
@@ -83,6 +85,8 @@ var _ = Describe("CreateVM", func() {
 			registryClient,
 			registryOptions,
 			agentOptions,
+			blobstore,
+			ntp,
 			defaultRootDiskSizeGb,
 			defaultRootDiskType,
 			"fake-default-zone",
@@ -380,6 +384,8 @@ var _ = Describe("CreateVM", func() {
 					registryClient,
 					registryOptions,
 					agentOptions,
+					blobstore,
+					ntp,
 					defaultRootDiskSizeGb,
 					defaultRootDiskType,
 					"fake-default-zone",
@@ -443,6 +449,8 @@ var _ = Describe("CreateVM", func() {
 					registryClient,
 					registryOptions,
 					agentOptions,
+					blobstore,
+					ntp,
 					defaultRootDiskSizeGb,
 					defaultRootDiskType,
 					"fake-default-zone",

--- a/src/bosh-google-cpi/config/config_test.go
+++ b/src/bosh-google-cpi/config/config_test.go
@@ -22,10 +22,10 @@ var validGoogleConfig = bgcconfig.Config{
 var validActionsOptions = bgcaction.ConcreteFactoryOptions{
 	Agent: registry.AgentOptions{
 		Mbus: "fake-mbus",
-		Ntp:  []string{},
-		Blobstore: registry.BlobstoreOptions{
-			Type: "fake-blobstore-type",
-		},
+	},
+	Ntp: []string{},
+	Blobstore: registry.BlobstoreOptions{
+		Type: "fake-blobstore-type",
 	},
 	Registry: registry.ClientOptions{
 		Protocol: "http",

--- a/src/bosh-google-cpi/integration/config.go
+++ b/src/bosh-google-cpi/integration/config.go
@@ -49,10 +49,10 @@ var (
 	  },
 	  "actions": {
 		"agent": {
-		  "mbus": "http://127.0.0.1",
-		  "blobstore": {
+		  "mbus": "http://127.0.0.1"
+		},
+		"blobstore": {
 			"type": "local"
-		  }
 		},
 		"registry": {
 		  "use_gce_metadata": true

--- a/src/bosh-google-cpi/registry/agent_options.go
+++ b/src/bosh-google-cpi/registry/agent_options.go
@@ -8,12 +8,6 @@ import (
 type AgentOptions struct {
 	// Mbus URI
 	Mbus string
-
-	// List of NTP servers
-	Ntp []string
-
-	// Blobstore options
-	Blobstore BlobstoreOptions
 }
 
 // BlobstoreOptions are the blobstore options passed to the BOSH Agent (http://bosh.io/docs/bosh-components.html#agent).
@@ -29,11 +23,6 @@ type BlobstoreOptions struct {
 func (o AgentOptions) Validate() error {
 	if o.Mbus == "" {
 		return bosherr.Error("Must provide a non-empty Mbus")
-	}
-
-	err := o.Blobstore.Validate()
-	if err != nil {
-		return bosherr.WrapError(err, "Validating Blobstore configuration")
 	}
 
 	return nil

--- a/src/bosh-google-cpi/registry/agent_settings.go
+++ b/src/bosh-google-cpi/registry/agent_settings.go
@@ -110,7 +110,7 @@ type VMSettings struct {
 }
 
 // NewAgentSettings creates new agent settings for a VM.
-func NewAgentSettings(agentID string, vmCID string, networksSettings NetworksSettings, env EnvSettings, agentOptions AgentOptions) AgentSettings {
+func NewAgentSettings(agentID string, vmCID string, networksSettings NetworksSettings, env EnvSettings, agentOptions AgentOptions, blobstoreOptions BlobstoreOptions, ntp []string) AgentSettings {
 	agentSettings := AgentSettings{
 		AgentID: agentID,
 		Disks: DisksSettings{
@@ -118,13 +118,13 @@ func NewAgentSettings(agentID string, vmCID string, networksSettings NetworksSet
 			Persistent: map[string]PersistentSettings{},
 		},
 		Blobstore: BlobstoreSettings{
-			Provider: agentOptions.Blobstore.Type,
-			Options:  agentOptions.Blobstore.Options,
+			Provider: blobstoreOptions.Type,
+			Options:  blobstoreOptions.Options,
 		},
 		Env:      EnvSettings(env),
 		Mbus:     agentOptions.Mbus,
 		Networks: networksSettings,
-		Ntp:      agentOptions.Ntp,
+		Ntp:      ntp,
 		VM: VMSettings{
 			Name: vmCID,
 		},


### PR DESCRIPTION
Addresses #31 by restructuring the mbus, ntp, and blobstore configuration
properties to be consistent with existing CPIs.