### PR TITLE
all: Normalize cloud_provider options for bosh-init

### DIFF
--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -225,13 +225,9 @@ cloud_provider:
 
   properties:
     google: *google_properties
-    agent:
-      mbus: https://mbus:mbus-password@0.0.0.0:6868
-      blobstore:
-        provider: local
-        options:
-          blobstore_path: /var/vcap/micro_bosh/data/cache
-      ntp: *ntp
+    agent: {mbus: "https://mbus:mbus-password@0.0.0.0:6868"}
+    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
+    ntp: *ntp
 EOF
 
 pushd ${deployment_dir}

--- a/jobs/google_cpi/spec
+++ b/jobs/google_cpi/spec
@@ -27,14 +27,28 @@ properties:
     description: "The name of the default Google Compute Engine Disk Type the CPI will use when creating the instances root disk"
     default: ""
 
+  blobstore.provider:
+    description: Provider of the blobstore used by director and agent (dav|simple)
+    default: 'dav'
+  blobstore.path:
+    description: local blobstore path
+  blobstore.address:
+    description: Address of blobstore server used by simple blobstore plugin
+  blobstore.port:
+    description: Port of blobstore server used by simple blobstore plugin
+    default: 25250
+  blobstore.agent.user:
+    description: Username agent uses to connect to blobstore used by simple blobstore plugin
+  blobstore.agent.password:
+    description: Password agent uses to connect to blobstore used by simple blobstore plugin
+    
+  ntp:
+    description: List of ntp server IPs
+    default:
+      - 169.254.169.254
+
   agent.mbus:
     description: "Mbus URL used by deployed BOSH agents"
-  agent.ntp:
-    description: "NTP configuration used by deployed BOSH agents"
-    default: []
-  agent.blobstore.provider:
-    description: "Provider type for the blobstore used by deployed BOSH agents (e.g. dav, s3)"
-    default: "dav"
   agent.blobstore.options:
     description: "Options for the blobstore used by deployed BOSH agents"
     default: {}

--- a/jobs/google_cpi/templates/config/cpi.json.erb
+++ b/jobs/google_cpi/templates/config/cpi.json.erb
@@ -1,24 +1,70 @@
 <%=
-JSON.dump(
-  "google" => {
-    "project" => p("google.project"),
-    "default_zone" => p("google.default_zone"),
-    "json_key" => p("google.json_key"),
-    "default_root_disk_size_gb" => p("google.default_root_disk_size_gb"),
-    "default_root_disk_type" => p("google.default_root_disk_type"),
-  },
-  "actions" => {
-    "agent" => {
-      "mbus" => p("agent.mbus"),
-      "ntp"  => p("agent.ntp"),
-      "blobstore" => {
-        "type"    => p("agent.blobstore.provider"),
-        "options" => p("agent.blobstore.options"),
+params = {
+  "cloud" => {
+    "plugin" => "google",
+    "properties" => {
+      "google" => {
+        "project" => p("google.project"),
+        "default_zone" => p("google.default_zone"),
+        "json_key" => p("google.json_key"),
+        "default_root_disk_size_gb" => p("google.default_root_disk_size_gb"),
+        "default_root_disk_type" => p("google.default_root_disk_type")
       },
-    },
-    "registry" => {
-      "use_gce_metadata" => true,
-    },
+      "registry" => {
+        "use_gce_metadata" => true
+      },
+      "agent" => {
+        "ntp" => p('ntp')
+      }
+    }
   }
-)
+}
+
+if_p('google.project') do |project|
+  params["cloud"]["properties"]["google"]["project"] = project
+end
+if_p('google.default_zone') do |default_zone|
+  params["cloud"]["properties"]["google"]["default_zone"] = default_zone
+end
+if_p('google.json_key') do |json_key|
+  params["cloud"]["properties"]["google"]["json_key"] = json_key
+end
+if_p('google.default_root_disk_size_gb') do |default_root_disk_size_gb|
+  params["cloud"]["properties"]["google"]["default_root_disk_size_gb"] = default_root_disk_size_gb
+end
+if_p('google.default_root_disk_type') do |default_root_disk_type|
+  params["cloud"]["properties"]["google"]["default_root_disk_type"] = default_root_disk_type
+end
+
+
+agent_params = params["cloud"]["properties"]["agent"]
+
+if_p('blobstore') do
+  agent_params["blobstore"] = {
+       "provider" => p('blobstore.provider'),
+       "options" => {}
+  }
+
+  blobstore = agent_params["blobstore"]
+
+  if p('blobstore.provider') == 'local'
+    blobstore["options"] = {
+      "blobstore_path" => p('blobstore.path')
+    }
+  else
+    blobstore["options"] = {
+      "endpoint" => "http://#{p(['agent.blobstore.address', 'blobstore.address'])}:#{p('blobstore.port')}",
+      "user" => p('blobstore.agent.user'),
+      "password" => p('blobstore.agent.password')
+    }
+  end
+end
+
+if_p('agent.mbus') do |mbus|
+  agent_params["mbus"] = mbus
+end.else_if_p('nats') do
+  agent_params["mbus"] = "nats://#{p('nats.user')}:#{p('nats.password')}@#{p(['agent.nats.address', 'nats.address'])}:#{p('nats.port')}"
+end
+
+JSON.dump(params)
 %>

--- a/src/bosh-google-cpi/action/concrete_factory.go
+++ b/src/bosh-google-cpi/action/concrete_factory.go
@@ -5,6 +5,7 @@ import (
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"
 	boshuuid "github.com/cloudfoundry/bosh-utils/uuid"
 
+	"bosh-google-cpi/config"
 	"bosh-google-cpi/google/address_service"
 	"bosh-google-cpi/google/backendservice_service"
 	"bosh-google-cpi/google/client"
@@ -29,7 +30,7 @@ type ConcreteFactory struct {
 func NewConcreteFactory(
 	googleClient client.GoogleClient,
 	uuidGen boshuuid.Generator,
-	options ConcreteFactoryOptions,
+	cfg config.Config,
 	logger boshlog.Logger,
 ) ConcreteFactory {
 	operationService := operation.NewGoogleOperationService(
@@ -89,16 +90,16 @@ func NewConcreteFactory(
 	// Choose the correct registry.Client based on the
 	// value of ClientOptions.UseGCEMetadata
 	var registryClient registry.Client
-	switch options.Registry.UseGCEMetadata {
+	switch cfg.Cloud.Properties.Registry.UseGCEMetadata {
 	case true:
 		registryClient = registry.NewMetadataClient(
 			googleClient,
-			options.Registry,
+			cfg.Cloud.Properties.Registry,
 			logger,
 		)
 	default:
 		registryClient = registry.NewHTTPClient(
-			options.Registry,
+			cfg.Cloud.Properties.Registry,
 			logger,
 		)
 	}
@@ -165,8 +166,8 @@ func NewConcreteFactory(
 				imageService,
 				machineTypeService,
 				registryClient,
-				options.Registry,
-				options.Agent,
+				cfg.Cloud.Properties.Registry,
+				cfg.Cloud.Properties.Agent,
 				googleClient.DefaultRootDiskSizeGb(),
 				googleClient.DefaultRootDiskType(),
 				googleClient.DefaultZone(),

--- a/src/bosh-google-cpi/action/concrete_factory_options_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_options_test.go
@@ -18,7 +18,7 @@ var _ = Describe("ConcreteFactoryOptions", func() {
 				Mbus: "fake-mbus",
 				Ntp:  []string{},
 				Blobstore: registry.BlobstoreOptions{
-					Type: "fake-blobstore-type",
+					Provider: "fake-blobstore-type",
 				},
 			},
 			Registry: registry.ClientOptions{

--- a/src/bosh-google-cpi/action/concrete_factory_test.go
+++ b/src/bosh-google-cpi/action/concrete_factory_test.go
@@ -10,6 +10,7 @@ import (
 
 	clientfakes "bosh-google-cpi/google/client/fakes"
 
+	"bosh-google-cpi/config"
 	"bosh-google-cpi/google/address_service"
 	"bosh-google-cpi/google/backendservice_service"
 	"bosh-google-cpi/google/client"
@@ -34,13 +35,17 @@ var _ = Describe("ConcreteFactory", func() {
 		googleClient client.GoogleClient
 		logger       boshlog.Logger
 
-		options = ConcreteFactoryOptions{
-			Registry: registry.ClientOptions{
-				Protocol: "http",
-				Host:     "fake-host",
-				Port:     5555,
-				Username: "fake-username",
-				Password: "fake-password",
+		cfg = config.Config{
+			Cloud: config.Cloud{
+				Properties: config.CPIProperties{
+					Registry: registry.ClientOptions{
+						Protocol: "http",
+						Host:     "fake-host",
+						Port:     5555,
+						Username: "fake-username",
+						Password: "fake-password",
+					},
+				},
 			},
 		}
 
@@ -72,7 +77,7 @@ var _ = Describe("ConcreteFactory", func() {
 		factory = NewConcreteFactory(
 			googleClient,
 			uuidGen,
-			options,
+			cfg,
 			logger,
 		)
 	})
@@ -140,7 +145,7 @@ var _ = Describe("ConcreteFactory", func() {
 		)
 
 		registryClient = registry.NewHTTPClient(
-			options.Registry,
+			cfg.Cloud.Properties.Registry,
 			logger,
 		)
 
@@ -248,8 +253,8 @@ var _ = Describe("ConcreteFactory", func() {
 			imageService,
 			machineTypeService,
 			registryClient,
-			options.Registry,
-			options.Agent,
+			cfg.Cloud.Properties.Registry,
+			cfg.Cloud.Properties.Agent,
 			googleClient.DefaultRootDiskSizeGb(),
 			googleClient.DefaultRootDiskType(),
 			googleClient.DefaultZone(),

--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -69,7 +69,7 @@ var _ = Describe("CreateVM", func() {
 		agentOptions = registry.AgentOptions{
 			Mbus: "http://fake-mbus",
 			Blobstore: registry.BlobstoreOptions{
-				Type: "fake-blobstore-type",
+				Provider: "fake-blobstore-type",
 			},
 		}
 		defaultRootDiskSizeGb = 0

--- a/src/bosh-google-cpi/config/config_test.go
+++ b/src/bosh-google-cpi/config/config_test.go
@@ -8,7 +8,6 @@ import (
 
 	fakesys "github.com/cloudfoundry/bosh-utils/system/fakes"
 
-	bgcaction "bosh-google-cpi/action"
 	bgcconfig "bosh-google-cpi/google/config"
 
 	"bosh-google-cpi/registry"
@@ -19,26 +18,31 @@ var validGoogleConfig = bgcconfig.Config{
 	DefaultZone: "fake-default-zone",
 }
 
-var validActionsOptions = bgcaction.ConcreteFactoryOptions{
-	Agent: registry.AgentOptions{
-		Mbus: "fake-mbus",
-		Ntp:  []string{},
-		Blobstore: registry.BlobstoreOptions{
-			Type: "fake-blobstore-type",
-		},
-	},
-	Registry: registry.ClientOptions{
-		Protocol: "http",
-		Host:     "fake-host",
-		Port:     5555,
-		Username: "fake-username",
-		Password: "fake-password",
+var validAgentOptions = registry.AgentOptions{
+	Mbus: "fake-mbus",
+	Ntp:  []string{},
+	Blobstore: registry.BlobstoreOptions{
+		Provider: "fake-blobstore-type",
 	},
 }
 
+var validRegistryOptions = registry.ClientOptions{
+	Protocol: "http",
+	Host:     "fake-host",
+	Port:     5555,
+	Username: "fake-username",
+	Password: "fake-password",
+}
+
 var validConfig = Config{
-	Google:  validGoogleConfig,
-	Actions: validActionsOptions,
+	Cloud: Cloud{
+		Plugin: "google",
+		Properties: CPIProperties{
+			Google:   validGoogleConfig,
+			Agent:    validAgentOptions,
+			Registry: validRegistryOptions,
+		},
+	},
 }
 
 var _ = Describe("NewConfigFromPath", func() {
@@ -101,8 +105,8 @@ var _ = Describe("Config", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("returns error if goole section is not valid", func() {
-			config.Google = bgcconfig.Config{}
+		It("returns error if google section is not valid", func() {
+			config.Cloud.Properties.Google = bgcconfig.Config{}
 
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())
@@ -110,12 +114,13 @@ var _ = Describe("Config", func() {
 		})
 
 		It("returns error if actions section is not valid", func() {
-			config.Actions.Agent = registry.AgentOptions{}
-			config.Actions.Registry = registry.ClientOptions{}
+
+			config.Cloud.Properties.Agent = registry.AgentOptions{}
+			config.Cloud.Properties.Registry = registry.ClientOptions{}
 
 			err := config.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("Validating Actions configuration"))
+			Expect(err.Error()).To(ContainSubstring("Validating agent configuration"))
 		})
 	})
 })

--- a/src/bosh-google-cpi/main/main.go
+++ b/src/bosh-google-cpi/main/main.go
@@ -35,13 +35,13 @@ func main() {
 
 	flag.Parse()
 
-	config, err := config.NewConfigFromPath(*configFileOpt, fs)
+	cfg, err := config.NewConfigFromPath(*configFileOpt, fs)
 	if err != nil {
 		logger.Error(mainLogTag, "Loading config - %s", err.Error())
 		os.Exit(1)
 	}
 
-	dispatcher, err := buildDispatcher(config, logger, fs, cmdRunner, uuidGen)
+	dispatcher, err := buildDispatcher(cfg, logger, fs, cmdRunner, uuidGen)
 	if err != nil {
 		logger.Error(mainLogTag, "Building Dispatcher - %s", err)
 		os.Exit(1)
@@ -70,13 +70,13 @@ func basicDeps() (api.MultiLogger, boshsys.FileSystem, boshsys.CmdRunner, boshuu
 }
 
 func buildDispatcher(
-	config config.Config,
+	cfg config.Config,
 	logger api.MultiLogger,
 	fs boshsys.FileSystem,
 	cmdRunner boshsys.CmdRunner,
 	uuidGen boshuuid.Generator,
 ) (dispatcher.Dispatcher, error) {
-	googleClient, err := client.NewGoogleClient(config.Google, logger)
+	googleClient, err := client.NewGoogleClient(cfg.Cloud.Properties.Google, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func buildDispatcher(
 	actionFactory := action.NewConcreteFactory(
 		googleClient,
 		uuidGen,
-		config.Actions,
+		cfg,
 		logger,
 	)
 

--- a/src/bosh-google-cpi/registry/agent_options.go
+++ b/src/bosh-google-cpi/registry/agent_options.go
@@ -18,8 +18,8 @@ type AgentOptions struct {
 
 // BlobstoreOptions are the blobstore options passed to the BOSH Agent (http://bosh.io/docs/bosh-components.html#agent).
 type BlobstoreOptions struct {
-	// Blobstore type
-	Type string
+	// Blobstore provider
+	Provider string
 
 	// Blobstore options
 	Options map[string]interface{}
@@ -41,7 +41,7 @@ func (o AgentOptions) Validate() error {
 
 // Validate validates the Blobstore options.
 func (o BlobstoreOptions) Validate() error {
-	if o.Type == "" {
+	if o.Provider == "" {
 		return bosherr.Error("Must provide non-empty Type")
 	}
 

--- a/src/bosh-google-cpi/registry/agent_settings.go
+++ b/src/bosh-google-cpi/registry/agent_settings.go
@@ -118,7 +118,7 @@ func NewAgentSettings(agentID string, vmCID string, networksSettings NetworksSet
 			Persistent: map[string]PersistentSettings{},
 		},
 		Blobstore: BlobstoreSettings{
-			Provider: agentOptions.Blobstore.Type,
+			Provider: agentOptions.Blobstore.Provider,
 			Options:  agentOptions.Blobstore.Options,
 		},
 		Env:      EnvSettings(env),


### PR DESCRIPTION
Restructure the mbus, ntp, and blobstore configuration properties to be
consistent with existing CPIs. Addresses #31.

A `bosh-init` manifest's `cloud_provider.properties` section should include the following keys:

* `google`
* `agent`
* `blobstore`
* `ntp

For example:

```
properties:
      google: *google_properties
      agent: {mbus: "https://mbus:mbus-password@0.0.0.0:6868"}
      blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
      ntp: *ntp
```

This is a departure from previous versions of the CPI that expectd `agent` and `ntp` keys to children of the `agent` key. 