### PR TITLE
ci: Generate CPI sha1

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -36,6 +36,9 @@ jobs:
       - put: bosh-cpi-dev-artifacts
         params: {file: candidate/*.tgz}
 
+      - put: bosh-cpi-dev-artifacts-sha1
+        params: {file: candidate/*.tgz.sha1}
+
   - name: setup-infrastructure
     serial_groups: [run-bats, run-int]
     plan:
@@ -273,6 +276,13 @@ resources:
       json_key: {{google_json_key_data}}
       bucket:   {{google_releases_bucket_name}}
       regexp:   bosh-google-cpi-([0-9]+\.[0-9]+\.[0-9]+)\.tgz
+
+  - name: bosh-cpi-dev-artifacts-sha1
+    type: gcs-resource
+    source:
+      json_key: {{google_json_key_data}}
+      bucket:   {{google_releases_bucket_name}}
+      regexp:   bosh-google-cpi-([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha1
 
   - name: bosh-cpi-artifacts
     type: gcs-resource

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -16,4 +16,8 @@ pushd bosh-cpi-src
   bosh create release --name ${cpi_release_name} --version ${semver} --with-tarball
 popd
 
-mv bosh-cpi-src/dev_releases/${cpi_release_name}/${cpi_release_name}-${semver}.tgz candidate/
+image_path=bosh-cpi-src/dev_releases/${cpi_release_name}/${cpi_release_name}-${semver}.tgz
+echo -n $(sha1sum $image_path | awk '{print $1}') > $image_path.sha1
+
+mv ${image_path} candidate/
+mv ${image_path}.sha1 candidate/


### PR DESCRIPTION
This change generates a SHA1 and stores it alongside the CPI build candidate.