### PR TITLE
all: Support settings tags in all cloud_properties

### DIFF
--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -1,5 +1,9 @@
 package action
 
+import (
+	"bosh-google-cpi/google/instance_service"
+)
+
 type DiskCloudProperties struct {
 	DiskType string `json:"type,omitempty"`
 }
@@ -7,14 +11,14 @@ type DiskCloudProperties struct {
 type Environment map[string]interface{}
 
 type NetworkCloudProperties struct {
-	NetworkName         string      `json:"network_name,omitempty"`
-	SubnetworkName      string      `json:"subnetwork_name,omitempty"`
-	Tags                NetworkTags `json:"tags,omitempty"`
-	EphemeralExternalIP bool        `json:"ephemeral_external_ip,omitempty"`
-	IPForwarding        bool        `json:"ip_forwarding,omitempty"`
+	NetworkName         string        `json:"network_name,omitempty"`
+	SubnetworkName      string        `json:"subnetwork_name,omitempty"`
+	Tags                instance.Tags `json:"tags,omitempty"`
+	EphemeralExternalIP bool          `json:"ephemeral_external_ip,omitempty"`
+	IPForwarding        bool          `json:"ip_forwarding,omitempty"`
 }
 
-type NetworkTags []string
+type Tags []string
 
 type SnapshotMetadata struct {
 	Deployment string `json:"deployment,omitempty"`
@@ -43,6 +47,11 @@ type VMCloudProperties struct {
 	ServiceScopes     VMServiceScopes `json:"service_scopes,omitempty"`
 	TargetPool        string          `json:"target_pool,omitempty"`
 	BackendService    string          `json:"backend_service,omitempty"`
+	Tags              instance.Tags   `json:"tags,omitempty"`
+}
+
+func (n VMCloudProperties) Validate() error {
+	return n.Tags.Validate()
 }
 
 type VMServiceScopes []string

--- a/src/bosh-google-cpi/action/configure_networks_test.go
+++ b/src/bosh-google-cpi/action/configure_networks_test.go
@@ -6,6 +6,7 @@ import (
 
 	. "bosh-google-cpi/action"
 
+	instance "bosh-google-cpi/google/instance_service"
 	instancefakes "bosh-google-cpi/google/instance_service/fakes"
 
 	registryfakes "bosh-google-cpi/registry/fakes"
@@ -40,7 +41,7 @@ var _ = Describe("ConfigureNetworks", func() {
 					Default: []string{"fake-network-default"},
 					CloudProperties: NetworkCloudProperties{
 						NetworkName:         "fake-network-cloud-network-name",
-						Tags:                NetworkTags{"fake-network-cloud-network-tag"},
+						Tags:                instance.Tags([]string{"fake-network-cloud-network-tag"}),
 						EphemeralExternalIP: true,
 						IPForwarding:        false,
 					},

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -87,6 +87,11 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		return "", bosherr.WrapError(err, "Creating VM")
 	}
 
+	// Validate VM tags
+	if err = cloudProps.Validate(); err != nil {
+		return "", bosherr.WrapError(err, "Creating VM")
+	}
+
 	// Parse VM properties
 	vmProps := &instance.Properties{
 		Zone:              zone,
@@ -101,6 +106,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		ServiceScopes:     instance.ServiceScopes(cloudProps.ServiceScopes),
 		TargetPool:        cloudProps.TargetPool,
 		BackendService:    cloudProps.BackendService,
+		Tags:              cloudProps.Tags,
 	}
 
 	// Create VM

--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -122,7 +122,7 @@ var _ = Describe("CreateVM", func() {
 					Default: []string{"fake-network-default"},
 					CloudProperties: NetworkCloudProperties{
 						NetworkName:         "fake-network-cloud-network-name",
-						Tags:                NetworkTags{"fake-network-cloud-network-tag"},
+						Tags:                instance.Tags([]string{"fake-network-cloud-network-tag"}),
 						EphemeralExternalIP: true,
 						IPForwarding:        false,
 					},

--- a/src/bosh-google-cpi/action/networks.go
+++ b/src/bosh-google-cpi/action/networks.go
@@ -32,7 +32,7 @@ func (ns Networks) AsInstanceServiceNetworks() instance.Networks {
 			Default:             network.Default,
 			NetworkName:         network.CloudProperties.NetworkName,
 			SubnetworkName:      network.CloudProperties.SubnetworkName,
-			Tags:                instance.NetworkTags(network.CloudProperties.Tags),
+			Tags:                network.CloudProperties.Tags,
 			EphemeralExternalIP: network.CloudProperties.EphemeralExternalIP,
 			IPForwarding:        network.CloudProperties.IPForwarding,
 		}

--- a/src/bosh-google-cpi/action/networks_test.go
+++ b/src/bosh-google-cpi/action/networks_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Networks", func() {
 				CloudProperties: NetworkCloudProperties{
 					NetworkName:         "fake-network-1-cloud-network-name",
 					SubnetworkName:      "fake-network-1-cloud-subnetwork-name",
-					Tags:                NetworkTags{"fake-network-1-cloud-network-tag"},
+					Tags:                instance.Tags([]string{"fake-network-1-cloud-network-tag"}),
 					EphemeralExternalIP: true,
 					IPForwarding:        false,
 				},
@@ -54,7 +54,7 @@ var _ = Describe("Networks", func() {
 					Default:             []string{"fake-network-1-default"},
 					NetworkName:         "fake-network-1-cloud-network-name",
 					SubnetworkName:      "fake-network-1-cloud-subnetwork-name",
-					Tags:                instance.NetworkTags([]string{"fake-network-1-cloud-network-tag"}),
+					Tags:                instance.Tags([]string{"fake-network-1-cloud-network-tag"}),
 					EphemeralExternalIP: true,
 					IPForwarding:        false,
 				},

--- a/src/bosh-google-cpi/google/instance_service/instance_service.go
+++ b/src/bosh-google-cpi/google/instance_service/instance_service.go
@@ -37,6 +37,7 @@ type Properties struct {
 	ServiceScopes     ServiceScopes
 	TargetPool        string
 	BackendService    string
+	Tags              Tags
 }
 
 type ServiceScopes []string

--- a/src/bosh-google-cpi/google/instance_service/network_test.go
+++ b/src/bosh-google-cpi/google/instance_service/network_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Network", func() {
 			SubnetworkName:      "fake-dynamic-network-subnetwork-name",
 			EphemeralExternalIP: true,
 			IPForwarding:        false,
-			Tags:                NetworkTags{"fake-dynamic-network-network-tag"},
+			Tags:                Tags{"fake-dynamic-network-network-tag"},
 		}
 
 		vipNetwork = Network{
@@ -41,7 +41,7 @@ var _ = Describe("Network", func() {
 			SubnetworkName:      "fake-vip-network-subnetwork-name",
 			EphemeralExternalIP: false,
 			IPForwarding:        true,
-			Tags:                NetworkTags{"fake-vip-network-network-tag"},
+			Tags:                Tags{"fake-vip-network-network-tag"},
 		}
 
 		unknownNetwork = Network{Type: "unknown"}
@@ -76,7 +76,7 @@ var _ = Describe("Network", func() {
 
 			Context("when network tags are not valid", func() {
 				BeforeEach(func() {
-					dynamicNetwork.Tags = NetworkTags{"invalid_network_tag"}
+					dynamicNetwork.Tags = Tags{"invalid_network_tag"}
 				})
 
 				It("returns an error", func() {

--- a/src/bosh-google-cpi/google/instance_service/networks.go
+++ b/src/bosh-google-cpi/google/instance_service/networks.go
@@ -99,7 +99,7 @@ func (n Networks) CanIPForward() bool {
 	return network.IPForwarding
 }
 
-func (n Networks) Tags() NetworkTags {
+func (n Networks) Tags() Tags {
 	network := n.Network()
 
 	return network.Tags

--- a/src/bosh-google-cpi/google/instance_service/networks_test.go
+++ b/src/bosh-google-cpi/google/instance_service/networks_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Networks", func() {
 			SubnetworkName:      "fake-dynamic-network-subnetwork-name",
 			EphemeralExternalIP: true,
 			IPForwarding:        false,
-			Tags:                NetworkTags{"fake-dynamic-network-network-tag"},
+			Tags:                Tags{"fake-dynamic-network-network-tag"},
 		}
 		manualNetwork = Network{
 			Type:                "manual",
@@ -41,7 +41,7 @@ var _ = Describe("Networks", func() {
 			SubnetworkName:      "fake-manual-network-subnetwork-name",
 			EphemeralExternalIP: true,
 			IPForwarding:        false,
-			Tags:                NetworkTags{"fake-manual-network-network-tag"},
+			Tags:                Tags{"fake-manual-network-network-tag"},
 		}
 		vipNetwork = Network{
 			Type:                "vip",
@@ -54,7 +54,7 @@ var _ = Describe("Networks", func() {
 			SubnetworkName:      "fake-vip-network-subnetwork-name",
 			EphemeralExternalIP: false,
 			IPForwarding:        true,
-			Tags:                NetworkTags{"fake-vip-network-network-tag"},
+			Tags:                Tags{"fake-vip-network-network-tag"},
 		}
 
 		networks = Networks{
@@ -278,7 +278,7 @@ var _ = Describe("Networks", func() {
 
 	Describe("Tags", func() {
 		It("returns only the dynamic network Tags", func() {
-			Expect(networks.Tags()).To(Equal(NetworkTags{"fake-dynamic-network-network-tag"}))
+			Expect(networks.Tags()).To(Equal(Tags{"fake-dynamic-network-network-tag"}))
 		})
 	})
 })

--- a/src/bosh-google-cpi/integration/network_tests.go
+++ b/src/bosh-google-cpi/integration/network_tests.go
@@ -63,9 +63,8 @@ var _ = Describe("Network", func() {
 				  "default": {
 					"type": "dynamic",
 					"cloud_properties": {
-					  "tags": ["integration-delete"],
 					  "network_name": "%v",
-					  "tags": ["tag1", "tag2"]
+					  "tags": ["integration-delete", "tag1", "tag2"]
 					}
 				  }
 				},
@@ -75,7 +74,7 @@ var _ = Describe("Network", func() {
 			}`, existingStemcell, networkName)
 		vmCID = assertSucceedsWithResult(request).(string)
 		assertValidVM(vmCID, func(instance *compute.Instance) {
-			Expect(instance.Tags.Items).To(ConsistOf("tag1", "tag2"))
+			Expect(instance.Tags.Items).To(ConsistOf("integration-delete", "tag1", "tag2"))
 		})
 
 		By("deleting the VM")


### PR DESCRIPTION
This change allows defining instance tags via any `cloud_properties` section of a BOSH manifest. Previously, tags could only be set via a network's `cloud_properties`.