### PR TITLE
Improve CI

### DIFF
--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -110,7 +110,7 @@ jobs:
             google_address_int_ubuntu:      {{google_address_int_ubuntu}}
 
   - name: deploy-ubuntu
-    serial_groups: [run-bats, run-int]
+    serial_groups: [run-bats]
     plan:
       - aggregate:
         - {trigger: true, passed: [build-candidate, setup-infrastructure],  get: bosh-cpi-src, resource: bosh-cpi-src-in}
@@ -118,7 +118,6 @@ jobs:
         - {trigger: true, passed: [setup-infrastructure],                   get: stemcell, resource: google-ubuntu-stemcell}
         - {trigger: false,                                                  get: bosh-init}
         - {trigger: false,                                                  get: bosh-release}
-        - {trigger: false,                                                  get: dummy-boshrelease}
 
       - task: setup-director
         file: bosh-cpi-src/ci/tasks/setup-director.yml
@@ -140,28 +139,6 @@ jobs:
             private_key_data:               {{private_key_data}}
             director_username:              {{director_username}}
             director_password:              {{director_password}}
-        on_failure:
-          task: teardown-director
-          file: bosh-cpi-src/ci/tasks/teardown-director.yml
-
-      - task: deploy-dummy
-        file: bosh-cpi-src/ci/tasks/deploy-dummy.yml
-        config:
-          params:
-            google_project:           {{google_project}}
-            google_region:            {{google_region}}
-            google_zone:              {{google_zone}}
-            google_json_key_data:     {{google_json_key_data}}
-            google_network:           {{google_network}}
-            google_subnetwork:        {{google_subnetwork}}
-            google_subnetwork_range:  {{google_subnetwork_range}}
-            google_subnetwork_gw:     {{google_subnetwork_gw}}
-            google_firewall_internal: {{google_firewall_internal}}
-            google_address_director:  {{google_address_director_ubuntu}}
-            base_os:                  Ubuntu
-            stemcell_name:            bosh-google-kvm-ubuntu-trusty-go_agent
-            director_username:        {{director_username}}
-            director_password:        {{director_password}}
         on_failure:
           task: teardown-director
           file: bosh-cpi-src/ci/tasks/teardown-director.yml
@@ -203,8 +180,8 @@ jobs:
     serial_groups: [run-int]
     plan:
       - aggregate:
-        - {trigger: true, passed: [build-candidate, deploy-ubuntu], get: bosh-cpi-src, resource: bosh-cpi-src-in}
-        - {trigger: true, passed: [deploy-ubuntu],                  get: stemcell, resource: google-ubuntu-stemcell}
+        - {trigger: true, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
+        - {trigger: true, passed: [setup-infrastructure],                  get: stemcell, resource: google-ubuntu-stemcell}
 
       - task: run-int
         file: bosh-cpi-src/ci/tasks/run-int.yml
@@ -292,12 +269,6 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry/bosh-acceptance-tests.git
-      branch: master
-
-  - name: dummy-boshrelease
-    type: git
-    source:
-      uri: https://github.com/pivotal-cf-experimental/dummy-boshrelease.git
       branch: master
 
   - name: google-ubuntu-stemcell

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -175,7 +175,6 @@ jobs:
         - {trigger: true, passed: [build-candidate, deploy-ubuntu], get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true, passed: [deploy-ubuntu],                  get: stemcell, resource: google-ubuntu-stemcell}
         - {trigger: false, passed: [deploy-ubuntu],    get: bosh-cpi-release,       resource: bosh-cpi-dev-artifacts}
-
         - {trigger: false,                                          get: bats}
 
       - task: run-bats

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -24,12 +24,12 @@ export NETWORK_NAME=${google_auto_network}
 export CUSTOM_NETWORK_NAME=${google_network}
 export CUSTOM_SUBNETWORK_NAME=${google_subnetwork}
 export PRIVATE_IP=${google_address_static_int}
-export STEMCELL_URL=${stemcell_url}
 export TARGET_POOL=${google_target_pool}
 export BACKEND_SERVICE=${google_backend_service}
 export ZONE=${google_zone}
 export REGION=${google_region}
 export GOOGLE_PROJECT=${google_project}
+export STEMCELL_URL=`cat stemcell/url | sed "s|gs://|https://storage.googleapis.com/|"`
 
 echo "Setting up artifacts..."
 cp ./stemcell/*.tgz stemcell.tgz

--- a/src/bosh-google-cpi/integration/config.go
+++ b/src/bosh-google-cpi/integration/config.go
@@ -31,13 +31,13 @@ var (
 	googleProject    = os.Getenv("GOOGLE_PROJECT")
 	externalStaticIP = os.Getenv("EXTERNAL_STATIC_IP")
 	keepResuableVM   = os.Getenv("KEEP_REUSABLE_VM")
+	stemcellURL      = os.Getenv("STEMCELL_URL")
 
 	// Configurable defaults
 	networkName          = envOrDefault("NETWORK_NAME", "cfintegration")
 	customNetworkName    = envOrDefault("CUSTOM_NETWORK_NAME", "cfintegration-custom")
 	customSubnetworkName = envOrDefault("CUSTOM_SUBNETWORK_NAME", "cfintegration-custom-us-central1")
 	ip                   = envOrDefault("PRIVATE_IP", "192.168.100.102")
-	stemcellURL          = envOrDefault("STEMCELL_URL", "https://storage.googleapis.com/evandbrown17/bosh-stemcell-3215-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz")
 	targetPool           = envOrDefault("TARGET_POOL", "cfintegration")
 	backendService       = envOrDefault("BACKEND_SERVICE", "cfintegration")
 	instanceGroup        = envOrDefault("BACKEND_SERVICE", "cfintegration-us-central1-a")


### PR DESCRIPTION
This change removes the dummy BOSH deployment when BATS is used. It also uses the Concourse stemcell resource for integration tests.