### PR TITLE
Certain network configuration can be overridden in VM properties

### DIFF
--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -34,20 +34,22 @@ type StemcellCloudProperties struct {
 }
 
 type VMCloudProperties struct {
-	Zone              string          `json:"zone,omitempty"`
-	Name              string          `json:"name,omitempty"`
-	MachineType       string          `json:"machine_type,omitempty"`
-	CPU               int             `json:"cpu,omitempty"`
-	RAM               int             `json:"ram,omitempty"`
-	RootDiskSizeGb    int             `json:"root_disk_size_gb,omitempty"`
-	RootDiskType      string          `json:"root_disk_type,omitempty"`
-	AutomaticRestart  bool            `json:"automatic_restart,omitempty"`
-	OnHostMaintenance string          `json:"on_host_maintenance,omitempty"`
-	Preemptible       bool            `json:"preemptible,omitempty"`
-	ServiceScopes     VMServiceScopes `json:"service_scopes,omitempty"`
-	TargetPool        string          `json:"target_pool,omitempty"`
-	BackendService    string          `json:"backend_service,omitempty"`
-	Tags              instance.Tags   `json:"tags,omitempty"`
+	Zone                string          `json:"zone,omitempty"`
+	Name                string          `json:"name,omitempty"`
+	MachineType         string          `json:"machine_type,omitempty"`
+	CPU                 int             `json:"cpu,omitempty"`
+	RAM                 int             `json:"ram,omitempty"`
+	RootDiskSizeGb      int             `json:"root_disk_size_gb,omitempty"`
+	RootDiskType        string          `json:"root_disk_type,omitempty"`
+	AutomaticRestart    bool            `json:"automatic_restart,omitempty"`
+	OnHostMaintenance   string          `json:"on_host_maintenance,omitempty"`
+	Preemptible         bool            `json:"preemptible,omitempty"`
+	ServiceScopes       VMServiceScopes `json:"service_scopes,omitempty"`
+	TargetPool          string          `json:"target_pool,omitempty"`
+	BackendService      string          `json:"backend_service,omitempty"`
+	Tags                instance.Tags   `json:"tags,omitempty"`
+	EphemeralExternalIP *bool           `json:"ephemeral_external_ip,omitempty"`
+	IPForwarding        *bool           `json:"ip_forwarding,omitempty"`
 }
 
 func (n VMCloudProperties) Validate() error {

--- a/src/bosh-google-cpi/action/configure_networks_test.go
+++ b/src/bosh-google-cpi/action/configure_networks_test.go
@@ -32,7 +32,7 @@ var _ = Describe("ConfigureNetworks", func() {
 	Describe("Run", func() {
 		BeforeEach(func() {
 			networks = Networks{
-				"fake-network-name": Network{
+				"fake-network-name": &Network{
 					Type:    "dynamic",
 					IP:      "fake-network-ip",
 					Gateway: "fake-network-gateway",

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -87,6 +87,15 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		return "", bosherr.WrapError(err, "Creating VM")
 	}
 
+	// Certain properties defined in the Networks section of a manifest can be
+	// overridden by VM properties. Here, we see if any of the VM properties
+	// have been set and should override Network settings
+	if cloudProps.IPForwarding != nil {
+		vmNetworks.Network().IPForwarding = *cloudProps.IPForwarding
+	}
+	if cloudProps.EphemeralExternalIP != nil {
+		vmNetworks.Network().EphemeralExternalIP = *cloudProps.EphemeralExternalIP
+	}
 	// Validate VM tags
 	if err = cloudProps.Validate(); err != nil {
 		return "", bosherr.WrapError(err, "Creating VM")

--- a/src/bosh-google-cpi/action/networks.go
+++ b/src/bosh-google-cpi/action/networks.go
@@ -6,7 +6,7 @@ import (
 	"bosh-google-cpi/google/instance_service"
 )
 
-type Networks map[string]Network
+type Networks map[string]*Network
 
 type Network struct {
 	Type            string                 `json:"type,omitempty"`
@@ -23,7 +23,7 @@ func (ns Networks) AsInstanceServiceNetworks() instance.Networks {
 	networks := instance.Networks{}
 
 	for netName, network := range ns {
-		networks[netName] = instance.Network{
+		networks[netName] = &instance.Network{
 			Type:                network.Type,
 			IP:                  network.IP,
 			Gateway:             network.Gateway,

--- a/src/bosh-google-cpi/action/networks_test.go
+++ b/src/bosh-google-cpi/action/networks_test.go
@@ -18,7 +18,7 @@ var _ = Describe("Networks", func() {
 
 	BeforeEach(func() {
 		networks = Networks{
-			"fake-network-1-name": Network{
+			"fake-network-1-name": &Network{
 				Type:    "fake-network-1-type",
 				IP:      "fake-network-1-ip",
 				Gateway: "fake-network-1-gateway",
@@ -34,7 +34,7 @@ var _ = Describe("Networks", func() {
 					IPForwarding:        false,
 				},
 			},
-			"fake-network-2-name": Network{
+			"fake-network-2-name": &Network{
 				Type: "fake-network-2-type",
 				IP:   "fake-network-2-ip",
 				DHCP: true,
@@ -45,7 +45,7 @@ var _ = Describe("Networks", func() {
 	Describe("AsInstanceServiceNetworks", func() {
 		It("returns networks for the instance service", func() {
 			expectedInstanceNetworks := instance.Networks{
-				"fake-network-1-name": instance.Network{
+				"fake-network-1-name": &instance.Network{
 					Type:                "fake-network-1-type",
 					IP:                  "fake-network-1-ip",
 					Gateway:             "fake-network-1-gateway",
@@ -58,7 +58,7 @@ var _ = Describe("Networks", func() {
 					EphemeralExternalIP: true,
 					IPForwarding:        false,
 				},
-				"fake-network-2-name": instance.Network{
+				"fake-network-2-name": &instance.Network{
 					Type: "fake-network-2-type",
 					IP:   "fake-network-2-ip",
 				},

--- a/src/bosh-google-cpi/google/instance_service/networks.go
+++ b/src/bosh-google-cpi/google/instance_service/networks.go
@@ -6,7 +6,7 @@ import (
 
 const defaultNetworkName = "default"
 
-type Networks map[string]Network
+type Networks map[string]*Network
 
 func (n Networks) Validate() error {
 	var networks, vipNetworks int
@@ -37,7 +37,7 @@ func (n Networks) Validate() error {
 	return nil
 }
 
-func (n Networks) Network() Network {
+func (n Networks) Network() *Network {
 	for _, net := range n {
 		if !net.IsVip() {
 			// There can only be 1 dynamic or manual network
@@ -45,10 +45,10 @@ func (n Networks) Network() Network {
 		}
 	}
 
-	return Network{}
+	return &Network{}
 }
 
-func (n Networks) VipNetwork() Network {
+func (n Networks) VipNetwork() *Network {
 	for _, net := range n {
 		if net.IsVip() {
 			// There can only be 1 vip network
@@ -56,7 +56,7 @@ func (n Networks) VipNetwork() Network {
 		}
 	}
 
-	return Network{}
+	return &Network{}
 }
 
 func (n Networks) DNS() []string {

--- a/src/bosh-google-cpi/google/instance_service/networks_test.go
+++ b/src/bosh-google-cpi/google/instance_service/networks_test.go
@@ -10,14 +10,14 @@ import (
 var _ = Describe("Networks", func() {
 	var (
 		err            error
-		dynamicNetwork Network
-		manualNetwork  Network
-		vipNetwork     Network
+		dynamicNetwork *Network
+		manualNetwork  *Network
+		vipNetwork     *Network
 		networks       Networks
 	)
 
 	BeforeEach(func() {
-		dynamicNetwork = Network{
+		dynamicNetwork = &Network{
 			Type:                "dynamic",
 			IP:                  "fake-dynamic-network-ip",
 			Gateway:             "fake-dynamic-network-gateway",
@@ -30,7 +30,7 @@ var _ = Describe("Networks", func() {
 			IPForwarding:        false,
 			Tags:                Tags{"fake-dynamic-network-network-tag"},
 		}
-		manualNetwork = Network{
+		manualNetwork = &Network{
 			Type:                "manual",
 			IP:                  "fake-manual-network-ip",
 			Gateway:             "fake-manual-network-gateway",
@@ -43,7 +43,7 @@ var _ = Describe("Networks", func() {
 			IPForwarding:        false,
 			Tags:                Tags{"fake-manual-network-network-tag"},
 		}
-		vipNetwork = Network{
+		vipNetwork = &Network{
 			Type:                "vip",
 			IP:                  "fake-vip-network-ip",
 			Gateway:             "fake-vip-network-gateway",
@@ -73,7 +73,7 @@ var _ = Describe("Networks", func() {
 
 		Context("when networks are not valid", func() {
 			BeforeEach(func() {
-				networks = Networks{"fake-network-name": Network{Type: "unknown"}}
+				networks = Networks{"fake-network-name": &Network{Type: "unknown"}}
 			})
 
 			It("returns an error", func() {
@@ -175,7 +175,7 @@ var _ = Describe("Networks", func() {
 			})
 
 			It("returns an emtpy network", func() {
-				Expect(networks.Network()).To(Equal(Network{}))
+				Expect(networks.Network()).To(Equal(&Network{}))
 			})
 		})
 	})
@@ -197,7 +197,7 @@ var _ = Describe("Networks", func() {
 			})
 
 			It("returns an emtpy network", func() {
-				Expect(networks.Network()).To(Equal(Network{}))
+				Expect(networks.Network()).To(Equal(&Network{}))
 			})
 		})
 	})
@@ -213,7 +213,7 @@ var _ = Describe("Networks", func() {
 			})
 
 			It("returns an emtpy network", func() {
-				Expect(networks.VipNetwork()).To(Equal(Network{}))
+				Expect(networks.VipNetwork()).To(Equal(&Network{}))
 			})
 		})
 	})


### PR DESCRIPTION
`CanIPForward` and `EphemeralExternalIP` configuration - originally the domain of the `networks` section of a manifest - can be overridden in the VM section of a manifest. VM configuration takes precedence.
Addresses #52