### PR TITLE
CPI script bails on error

### DIFF
--- a/jobs/google_cpi/templates/bin/cpi.erb
+++ b/jobs/google_cpi/templates/bin/cpi.erb
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Set directories
 PACKAGES_DIR=${BOSH_PACKAGES_DIR:-/var/vcap/packages}
 JOBS_DIR=${BOSH_JOBS_DIR:-/var/vcap/jobs}


### PR DESCRIPTION
- The CPI script as it stands shouldn't ever error-out; this
  PR is merely about laying the groundwork for the future
  if the script becomes more complicated (e.g. passing
  in environment variables such as HTTPS_PROXY) -- we'd
  want the script to abort as soon as it encountered an
  error (we chased down a bug in the vSphere CPI which was
  caused partly by the CPI script not aborting).

Signed-off-by: Forrest Sill <fsill@pivotal.io>

[#128097379](https://www.pivotaltracker.com/story/show/128097379)