### PR TITLE
Allow light stemcell pipeline to publish to s3-compatible bucket

### DIFF
--- a/ci/stemcell/README.md
+++ b/ci/stemcell/README.md
@@ -1,6 +1,8 @@
 # BOSH Google Stemcell Concourse Pipeline
 
-In order to run the BOSH Google Stemcell Concourse Pipeline you must have an existing [Concourse](http://concourse.ci) environment. See [Deploying Concourse on Google Compute Engine](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/blob/master/docs/deploy_concourse.md) for instructions.
+The official BOSH Google Light Stemcells are produced [here](https://bosh-cpi.ci.cf-app.com/pipelines/light-gce-stemcells?groups=light-gce-stemcells).
+
+In order to create your own BOSH Google Stemcell Concourse Pipeline you must have an existing [Concourse](http://concourse.ci) environment. See [Deploying Concourse on Google Compute Engine](https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/blob/master/docs/deploy_concourse.md) for instructions.
 
 * Target your Concourse CI environment:
 

--- a/ci/stemcell/light/credentials.yml.tpl
+++ b/ci/stemcell/light/credentials.yml.tpl
@@ -1,4 +1,9 @@
 ---
-google_json_key_data: |
+google_raw_stemcells_bucket_name: <AN EXISTING GCS BUCKET TO STORE THE RAW MACHINE IMAGES>
+google_raw_stemcells_json_key_data: |
   <THE CONTENT OF YOUR GOOGLE ACCOUNT JSON KEY FILE>
-google_stemcells_bucket_name: <AN EXISTING GCS BUCKET TO STORE THE STEMCELLS>
+google_light_stemcells_bucket_name: <AN EXISTING S3 or GCS BUCKET TO STORE THE LIGHT STEMCELLS>
+google_light_stemcells_access_key_id: <ACCESS KEY FOR STEMCELL BUCKET>
+google_light_stemcells_secret_access_key: <SECRET KEY FOR STEMCELL BUCKET>
+google_light_stemcells_endpoint: <ENTER s3.amazonaws.com FOR AWS, storage.googleapis.com for GCS>
+google_light_stemcells_region: <REGION CONTAINING THE STEMCELL BUCKET>

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -1,15 +1,8 @@
 ---
 groups:
-  - name: bosh-google-stemcell
-    jobs:
-      - ubuntu-trusty-stemcell-google
-
-  - name: ubuntu
+  - name: light-gce-stemcells
     jobs:
       - ubuntu-trusty-stemcell
-
-  - name: centos
-    jobs:
       - centos-7-stemcell
 
 jobs:
@@ -23,40 +16,7 @@ jobs:
         file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
         privileged: true
         params:
-          BUCKET_NAME:     {{google_stemcells_bucket_name}}
-
-      - aggregate:
-        - put: bosh-ubuntu-raw-stemcells
-          params:
-            file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
-            predefined_acl: "publicRead"
-
-        - put: bosh-ubuntu-light-stemcells
-          params:
-            file: light-stemcell/light-bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent.tgz
-            predefined_acl: "publicRead"
-
-        - put: bosh-ubuntu-raw-stemcells-sha1
-          params:
-            file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
-            predefined_acl: "publicRead"
-
-        - put: bosh-ubuntu-light-stemcells-sha1
-          params:
-            file: light-stemcell/light-bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent.tgz.sha1
-            predefined_acl: "publicRead"
-
-  - name: ubuntu-trusty-stemcell-google
-    plan:
-      - aggregate:
-        - {trigger: true, get: stemcell, resource: ubuntu-stemcells-google}
-        - {trigger: false, get: bosh-cpi-src}
-
-      - task: create-light-stemcell
-        file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
-        privileged: true
-        params:
-          BUCKET_NAME:     {{google_stemcells_bucket_name}}
+          BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
 
       - aggregate:
         - put: bosh-ubuntu-raw-stemcells
@@ -89,7 +49,7 @@ jobs:
         file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
         privileged: true
         params:
-          BUCKET_NAME:     {{google_stemcells_bucket_name}}
+          BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
 
       - aggregate:
         - put: bosh-centos-raw-stemcells
@@ -119,80 +79,85 @@ resources:
       uri: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release.git
       branch: master
 
-  - name: centos-stemcells
-    type: s3
-    source:
-      regexp: bosh-stemcell-(.+)-google-kvm-centos-7-go_agent.tgz
-      bucket: bosh-google-stemcells-dev
-
   - name: ubuntu-stemcells
     type: s3
     source:
       regexp: bosh-stemcell-(.+)-google-kvm-ubuntu-trusty-go_agent.tgz
       bucket: bosh-google-stemcells-dev
 
-  - name: ubuntu-stemcells-google
-    type: gcs-resource
-    source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
-      regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz
-
   - name: bosh-ubuntu-raw-stemcells
     type: gcs-resource
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
+      json_key: {{google_raw_stemcells_json_key_data}}
+      bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
 
   - name: bosh-ubuntu-raw-stemcells-sha1
     type: gcs-resource
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
+      json_key: {{google_raw_stemcells_json_key_data}}
+      bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
 
   - name: bosh-ubuntu-light-stemcells
-    type: gcs-resource
+    type: s3
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
-      regexp:   light-bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz
+      bucket:            {{google_light_stemcells_bucket_name}}
+      access_key_id:     {{google_light_stemcells_access_key_id}}
+      secret_access_key: {{google_light_stemcells_secret_access_key}}
+      endpoint:          {{google_light_stemcells_endpoint}}
+      region:            {{google_light_stemcells_region}}
+      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz
 
   - name: bosh-ubuntu-light-stemcells-sha1
-    type: gcs-resource
+    type: s3
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
-      regexp:   light-bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz.sha1
+      bucket:            {{google_light_stemcells_bucket_name}}
+      access_key_id:     {{google_light_stemcells_access_key_id}}
+      secret_access_key: {{google_light_stemcells_secret_access_key}}
+      endpoint:          {{google_light_stemcells_endpoint}}
+      region:            {{google_light_stemcells_region}}
+      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz.sha1
+
+  - name: centos-stemcells
+    type: s3
+    source:
+      regexp: bosh-stemcell-(.+)-google-kvm-centos-7-go_agent.tgz
+      bucket: bosh-google-stemcells-dev
 
   - name: bosh-centos-raw-stemcells
     type: gcs-resource
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
+      json_key: {{google_raw_stemcells_json_key_data}}
+      bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent-raw.tar.gz
 
   - name: bosh-centos-raw-stemcells-sha1
     type: gcs-resource
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
+      json_key: {{google_raw_stemcells_json_key_data}}
+      bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent-raw.tar.gz.sha1
 
   - name: bosh-centos-light-stemcells
-    type: gcs-resource
+    type: s3
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
-      regexp:   light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz
+      bucket:            {{google_light_stemcells_bucket_name}}
+      access_key_id:     {{google_light_stemcells_access_key_id}}
+      secret_access_key: {{google_light_stemcells_secret_access_key}}
+      endpoint:          {{google_light_stemcells_endpoint}}
+      region:            {{google_light_stemcells_region}}
+      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz
 
   - name: bosh-centos-light-stemcells-sha1
-    type: gcs-resource
+    type: s3
     source:
-      json_key: {{google_json_key_data}}
-      bucket:   {{google_stemcells_bucket_name}}
-      regexp:   light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz.sha1
+      bucket:            {{google_light_stemcells_bucket_name}}
+      access_key_id:     {{google_light_stemcells_access_key_id}}
+      secret_access_key: {{google_light_stemcells_secret_access_key}}
+      endpoint:          {{google_light_stemcells_endpoint}}
+      region:            {{google_light_stemcells_region}}
+      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz.sha1
 
 resource_types:
   - name: gcs-resource


### PR DESCRIPTION
The SF BOSH Core / CPI teams are in the process of taking over production of GCE stemcells. This PR will allow us to publish light stemcells to an S3 bucket (bosh.io only understands S3). The new light stemcell pipeline will be available here: https://bosh-cpi.ci.cf-app.com/pipelines/light-gce-stemcells. We'll be adding a heavy GCE stemcell stage to BOSH Core's pipeline shortly.

[#127591235](https://www.pivotaltracker.com/story/show/127591235)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>