### PR TITLE
POST light stemcell checksum to bosh.io

### DIFF
--- a/ci/stemcell/light/credentials.yml.tpl
+++ b/ci/stemcell/light/credentials.yml.tpl
@@ -7,3 +7,4 @@ google_light_stemcells_access_key_id: <ACCESS KEY FOR STEMCELL BUCKET>
 google_light_stemcells_secret_access_key: <SECRET KEY FOR STEMCELL BUCKET>
 google_light_stemcells_endpoint: <ENTER s3.amazonaws.com FOR AWS, storage.googleapis.com for GCS>
 google_light_stemcells_region: <REGION CONTAINING THE STEMCELL BUCKET>
+google_boshio_checksum_token: "" # <SET TO A VALID TOKEN TO POST STEMCELL CHECKSUMS TO BOSH.IO, LEAVE EMPTY TO SKIP>

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -17,6 +17,7 @@ jobs:
         privileged: true
         params:
           BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
+          BOSHIO_TOKEN:    {{google_boshio_checksum_token}}
 
       - aggregate:
         - put: bosh-ubuntu-raw-stemcells
@@ -50,6 +51,7 @@ jobs:
         privileged: true
         params:
           BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
+          BOSHIO_TOKEN:    {{google_boshio_checksum_token}}
 
       - aggregate:
         - put: bosh-centos-raw-stemcells

--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -3,6 +3,7 @@
 set -e
 
 : ${BUCKET_NAME:?}
+: ${BOSHIO_TOKEN:=""}
 
 # inputs
 stemcell_dir="$PWD/stemcell"
@@ -31,5 +32,15 @@ pushd working_dir
 
   light_stemcell_path="${light_stemcell_dir}/${light_stemcell_name}"
   tar czvf "${light_stemcell_path}" *
-  echo -n $(sha1sum ${light_stemcell_path} | awk '{print $1}') > ${light_stemcell_path}.sha1
+
+  checksum="$(sha1sum ${light_stemcell_path} | awk '{print $1}')"
+  echo -n "${checksum}" > ${light_stemcell_path}.sha1
+
+  if [ -n "${BOSHIO_TOKEN}" ]; then
+    curl -X POST \
+      --fail \
+      -d "sha1=${checksum}" \
+      -H "Authorization: bearer ${BOSHIO_TOKEN}" \
+      "https://bosh.io/checksums/${light_stemcell_name}"
+  fi
 popd

--- a/ci/stemcell/light/tasks/build-light-stemcell.yml
+++ b/ci/stemcell/light/tasks/build-light-stemcell.yml
@@ -15,4 +15,5 @@ run:
   path: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.sh
 
 params:
-  BUCKET_NAME: ""
+  BUCKET_NAME:  ""
+  BOSHIO_TOKEN: ""


### PR DESCRIPTION
- More secure to store the shasum and the tarball in different places
- The bosh-io-stemcell concourse resource automatically performs the checksum validation
  on `get`

[#127591235](https://www.pivotaltracker.com/story/show/127591235)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>