### PR TITLE
Add zone to cloudfoundry manifest

### DIFF
--- a/.final_builds/packages/bosh-google-cpi/index.yml
+++ b/.final_builds/packages/bosh-google-cpi/index.yml
@@ -24,4 +24,8 @@ builds:
     version: 281942704cf3a64609890ea2c759c1ae99ed1680
     sha1: c5a2838a8cb0008949f66e161b74101e2e97e7c3
     blobstore_id: 8bf3994f-a75a-4eb3-b9ca-7003755a1bf7
+  080b5ce242f4a0ac0da1d2a3e07b65e8ab0d7015:
+    version: 080b5ce242f4a0ac0da1d2a3e07b65e8ab0d7015
+    sha1: a37ad63f832a596ab7b1c1484f225b671638385c
+    blobstore_id: 2910f781-69f9-4be5-b8cc-cc9f74496fad
 format-version: '2'

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Please see [CHANGELOG.md] for details of each release.
 |[24.3.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.3.0.tgz)|f62cebd284d682121a5b4075d0c60a47dd3981ca|2016-07-27|
 |[24.4.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.4.0.tgz)|0c8c8efc316e5d1e0b2e4665b88dfb044b4b87a3|2016-08-10|
 |[25.0.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.0.0.tgz)|701874022ea1d17e7cf2d829fde166aaacbdd1ed|2016-08-14|
+|[25.1.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.1.0.tgz)|f99dff6860731921282dd1bcd097a74beaeb72a4|2016-08-18|
 [//]: # (new-cpi)
 
 ### Stemcell
@@ -25,6 +26,7 @@ Please see [CHANGELOG.md] for details of each release.
 |[3262.2 (Heavy)](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-stemcell-3262.2-google-kvm-ubuntu-trusty-go_agent.tgz)|f294226d3ade9e27b67e4ef82b8cd5d3b4e23af7|2016-07-25|
 |[3262.4 (Light)](https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.4-google-kvm-ubuntu-trusty-go_agent.tgz)|1f44ee6fc5fd495113694aa772d636bf1a8d645a|2016-07-26|
 |[3262.5 (Light)](https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.5-google-kvm-ubuntu-trusty-go_agent.tgz)|b7ed64f1a929b9a8e906ad5faaed73134dc68c53|2016-08-10|
+|[3262.7 (Light)](https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.7-google-kvm-ubuntu-trusty-go_agent.tgz)|eccdb9f590f462f84083fe04894ddf27e886b53d|2016-08-18|
 [//]: # (new-stemcell)
 
 ## Usage

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -211,6 +211,7 @@ Before working this section, you must have deployed the supporting infrastructur
   $ sed -i s#{{VIP_IP}}#`gcloud compute addresses describe cf | grep ^address: | cut -f2 -d' '`# cloudfoundry.yml
   $ sed -i s#{{DIRECTOR_UUID}}#`bosh status --uuid 2>/dev/null`# cloudfoundry.yml
   $ sed -i s#{{REGION}}#$region# cloudfoundry.yml
+  sed -i s#{{ZONE}}#zone# cloudfoundry.yml
   ```
 
 1. Target the deployment file and deploy:

--- a/docs/cloudfoundry/cloudfoundry.yml
+++ b/docs/cloudfoundry/cloudfoundry.yml
@@ -9,6 +9,7 @@ deployment_name = "cf"
 
 # Google network settings
 google_region = "{{REGION}}"
+google_zone = "{{ZONE}}"
 network = "cf"
 public_subnetwork = "cf-public-#{google_region}"
 private_subnetwork = "cf-private-#{google_region}"
@@ -75,6 +76,7 @@ compilation:
   network: private
   reuse_compilation_vms: true
   cloud_properties:
+    zone: <%= google_zone%>
     machine_type: n1-standard-8
     root_disk_size_gb: 100
     root_disk_type: pd-ssd
@@ -94,6 +96,7 @@ networks:
     - range: 10.200.0.0/16
       gateway: 10.200.0.1
       cloud_properties:
+        zone: <%= google_zone%>
         network_name: <%= network%>
         subnetwork_name: <%= public_subnetwork%>
         ephemeral_external_ip: true
@@ -108,6 +111,7 @@ networks:
     - range: 192.168.0.0/16
       gateway: 192.168.0.1
       cloud_properties:
+        zone: <%= google_zone%>
         network_name: <%= network%>
         subnetwork_name: <%= private_subnetwork%>
         ephemeral_external_ip: true
@@ -125,6 +129,7 @@ resource_pools:
       name: bosh-google-kvm-ubuntu-trusty-go_agent
       version: latest
     cloud_properties:
+      zone: <%= google_zone%>
       machine_type: n1-standard-4
       root_disk_size_gb: 20
       root_disk_type: pd-standard
@@ -135,6 +140,7 @@ resource_pools:
       name: bosh-google-kvm-ubuntu-trusty-go_agent
       version: latest
     cloud_properties:
+      zone: <%= google_zone%>
       machine_type: n1-standard-4
       root_disk_size_gb: 20
       root_disk_type: pd-standard
@@ -146,6 +152,7 @@ resource_pools:
       name: bosh-google-kvm-ubuntu-trusty-go_agent
       version: latest
     cloud_properties:
+      zone: <%= google_zone%>
       machine_type: n1-highmem-8
       root_disk_size_gb: 100
       root_disk_type: pd-standard

--- a/releases/bosh-google-cpi/bosh-google-cpi-25.1.0.yml
+++ b/releases/bosh-google-cpi/bosh-google-cpi-25.1.0.yml
@@ -1,0 +1,26 @@
+---
+packages:
+- name: bosh-google-cpi
+  version: 080b5ce242f4a0ac0da1d2a3e07b65e8ab0d7015
+  fingerprint: 080b5ce242f4a0ac0da1d2a3e07b65e8ab0d7015
+  sha1: a37ad63f832a596ab7b1c1484f225b671638385c
+  dependencies:
+  - golang
+- name: golang
+  version: 1ad977ce1c6fdbf21485a79567ef3d8d4d280110
+  fingerprint: 1ad977ce1c6fdbf21485a79567ef3d8d4d280110
+  sha1: ee44afe3f736b317c489eaaeab273d008a17241f
+  dependencies: []
+jobs:
+- name: google_cpi
+  version: 9752c4687d7c8a6eff1025a7b31ad1daa9b1c53d
+  fingerprint: 9752c4687d7c8a6eff1025a7b31ad1daa9b1c53d
+  sha1: 15a5615eabafe0b0092a50fab841d1cd626c5f31
+license:
+  version: 9bb85bd388bb9bbd1b279f7921e71cd318007cb6
+  fingerprint: 9bb85bd388bb9bbd1b279f7921e71cd318007cb6
+  sha1: a208ac221870e2e599854cf7ecb8910335318b32
+commit_hash: 964a3c97
+uncommitted_changes: false
+name: bosh-google-cpi
+version: 25.1.0

--- a/releases/bosh-google-cpi/index.yml
+++ b/releases/bosh-google-cpi/index.yml
@@ -46,4 +46,6 @@ builds:
     version: 24.4.0
   5eff0228-6585-4639-9d63-3a21201fe7df:
     version: 25.0.0
+  ed02bd76-1428-4540-a543-1ee8a4218b6a:
+    version: 25.1.0
 format-version: '2'


### PR DESCRIPTION
Turns out that the sample cloudfoundry manifest is missing the CPI `cloud_properties.zone` key.

This PR adds that key