### PR TITLE
Apply BOSH tags to VM on create.

### DIFF
--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -95,6 +95,16 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 	if cloudProps.EphemeralExternalIP != nil {
 		vmNetworks.Network().EphemeralExternalIP = *cloudProps.EphemeralExternalIP
 	}
+
+	// Extract any tags from env.bosh.groups
+	if boshenv, ok := env["bosh"]; ok {
+		if boshgroups, ok := boshenv.(map[string]interface{})["groups"]; ok {
+			for _, tag := range boshgroups.([]interface{}) {
+				cloudProps.Tags = append(cloudProps.Tags, tag.(string))
+			}
+		}
+	}
+
 	// Validate VM tags
 	if err = cloudProps.Validate(); err != nil {
 		return "", bosherr.WrapError(err, "Creating VM")

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -61,7 +61,12 @@ var _ = Describe("VM", func() {
 				  }
 				},
 				[],
-				{}
+				{
+				  "bosh": {
+					  "group_name": "micro-google-dummy-dummy",
+					  "groups": ["micro-google", "dummy", "dummy", "micro-google-dummy", "dummy-dummy", "micro-google-dummy-dummy"]
+				  }
+				}
 			  ]
 			}`, existingStemcell, zone, networkName)
 		vmCID = assertSucceedsWithResult(request).(string)
@@ -84,12 +89,17 @@ var _ = Describe("VM", func() {
 			"integration-delete": "",
 		}
 		expectLabels := map[string]string{
-			"director":           "val-that-is-definitely-for-sure-absolutely-longer-than-the-al",
-			"name":               "val-with-underscores-ending-in-dash",
-			"deployment":         "deployment-name",
-			"job":                "job-name",
-			"index":              "n0",
-			"integration-delete": "",
+			"director":                 "val-that-is-definitely-for-sure-absolutely-longer-than-the-al",
+			"name":                     "val-with-underscores-ending-in-dash",
+			"deployment":               "deployment-name",
+			"job":                      "job-name",
+			"index":                    "n0",
+			"integration-delete":       "",
+			"micro-google":             "",
+			"dummy":                    "",
+			"micro-google-dummy":       "",
+			"dummy-dummy":              "",
+			"micro-google-dummy-dummy": "",
 		}
 		mj, _ := json.Marshal(m)
 		request = fmt.Sprintf(`{


### PR DESCRIPTION
If `bosh.groups` is set in the `env` hash on instance create, those
values will be applied as VM tags.

Addresses #73 