### PR TITLE
Switches metadata service host to IP address

### DIFF
--- a/src/bosh-google-cpi/google/client/google_client.go
+++ b/src/bosh-google-cpi/google/client/google_client.go
@@ -19,7 +19,9 @@ import (
 const (
 	computeScope = compute.ComputeScope
 	storageScope = storage.DevstorageFullControlScope
-	metadataHost = "metadata.google.internal"
+	// Metadata Host needs to be IP address, rather than FQDN, in case the system
+	// is set up to use public DNS servers, which would not resolve correctly.
+	metadataHost = "169.254.169.254"
 )
 
 type GoogleClient struct {


### PR DESCRIPTION
In cases in which users have public DNS servers configured, the metadata
service domain lookup will fail. We can be certain that the IP address
is always correct, so use that.

Signed-off-by: Derek Richard <drichard@pivotal.io>