### PR TITLE
Sanitize tags on VM create

### DIFF
--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -100,7 +100,9 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 	if boshenv, ok := env["bosh"]; ok {
 		if boshgroups, ok := boshenv.(map[string]interface{})["groups"]; ok {
 			for _, tag := range boshgroups.([]interface{}) {
-				cloudProps.Tags = append(cloudProps.Tags, tag.(string))
+				// Ignore error as labels will be validated later
+				safeTag, _ := instance.SafeLabel(tag.(string))
+				cloudProps.Tags = append(cloudProps.Tags, safeTag)
 			}
 		}
 	}

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -64,7 +64,7 @@ var _ = Describe("VM", func() {
 				{
 				  "bosh": {
 					  "group_name": "micro-google-dummy-dummy",
-					  "groups": ["micro-google", "dummy", "dummy", "micro-google-dummy", "dummy-dummy", "micro-google-dummy-dummy"]
+					  "groups": ["micro-google", "dummy", "dummy", "micro-google-dummy", "dummy-dummy", "micro-google-dummy-dummy-too-long-and-should-be-truncated-to-an-acceptable-length"]
 				  }
 				}
 			  ]
@@ -89,17 +89,17 @@ var _ = Describe("VM", func() {
 			"integration-delete": "",
 		}
 		expectLabels := map[string]string{
-			"director":                 "val-that-is-definitely-for-sure-absolutely-longer-than-the-al",
-			"name":                     "val-with-underscores-ending-in-dash",
-			"deployment":               "deployment-name",
-			"job":                      "job-name",
-			"index":                    "n0",
-			"integration-delete":       "",
-			"micro-google":             "",
-			"dummy":                    "",
-			"micro-google-dummy":       "",
-			"dummy-dummy":              "",
-			"micro-google-dummy-dummy": "",
+			"director":           "val-that-is-definitely-for-sure-absolutely-longer-than-the-al",
+			"name":               "val-with-underscores-ending-in-dash",
+			"deployment":         "deployment-name",
+			"job":                "job-name",
+			"index":              "n0",
+			"integration-delete": "",
+			"micro-google":       "",
+			"dummy":              "",
+			"micro-google-dummy": "",
+			"dummy-dummy":        "",
+			"micro-google-dummy-dummy-too-long-and-should-be-truncated-to": "",
 		}
 		mj, _ := json.Marshal(m)
 		request = fmt.Sprintf(`{


### PR DESCRIPTION
When a VM is created, BOSH may apply tags automatically. These tags may violate
constraints in the GCE API. This change sanitizes those tags to conform to the
GCE API before applying them.