### PR TITLE
Light stemcell pipeline publishes to bosh.io

### DIFF
--- a/ci/stemcell/light/credentials.yml.tpl
+++ b/ci/stemcell/light/credentials.yml.tpl
@@ -8,3 +8,11 @@ google_light_stemcells_secret_access_key: <SECRET KEY FOR STEMCELL BUCKET>
 google_light_stemcells_endpoint: <ENTER s3.amazonaws.com FOR AWS, storage.googleapis.com for GCS>
 google_light_stemcells_region: <REGION CONTAINING THE STEMCELL BUCKET>
 google_boshio_checksum_token: "" # <SET TO A VALID TOKEN TO POST STEMCELL CHECKSUMS TO BOSH.IO, LEAVE EMPTY TO SKIP>
+ssh_private_key: |
+  <GCE SSH KEY, USED TO VERIFY STEMCELL BOOTS>
+gce_credentials_json: |
+  <GCE SERVICE ACCOUNT KEY WITH PERMISSION TO CREATE NETWORKS + INSTANCES>
+gce_project_id: <GCE PROJECT ID USED TO APPLY TERRAFORM TEMPLATE>
+terraform_bucket_name: <GCS BUCKET TO STORE TERRAFORM STATE FILES>
+terraform_bucket_access_key: <GCS S3-COMPATIBLE KEY TO ACCESS BUCKET>
+terraform_bucket_secret_key: <GCS S3-COMPATIBLE SECRET TO ACCESS BUCKET>

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -3,101 +3,120 @@ groups:
   - name: light-gce-stemcells
     jobs:
       - ubuntu-trusty-stemcell
-      - centos-7-stemcell
 
 jobs:
   - name: ubuntu-trusty-stemcell
     plan:
       - aggregate:
-        - {trigger: true, get: stemcell, resource: ubuntu-stemcells}
-        - {trigger: false, get: bosh-cpi-src}
-
+        - get: stemcell
+          resource: ubuntu-stemcells
+          trigger: true
+          version: every
+          params:
+            preserve_filename: true
+        - get: bosh-cpi-src
+          trigger: false
+        - get: bosh-cli
+          trigger: false
+        - get: bosh-cpi-release
+          trigger: false
       - task: create-light-stemcell
         file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
-        privileged: true
         params:
           BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
-          BOSHIO_TOKEN:    {{google_boshio_checksum_token}}
 
       - aggregate:
         - put: bosh-ubuntu-raw-stemcells
           params:
             file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
             predefined_acl: "publicRead"
+        - put: bosh-ubuntu-raw-stemcells-sha1
+          params:
+            file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
+            predefined_acl: "publicRead"
+
+      - do:
+        - put: terraform
+          params:
+            generate_random_name: true
+            terraform_source: bosh-cpi-src/ci/stemcell/light/terraform/
+
+        - task: deploy-skeletal
+          file: bosh-cpi-src/ci/stemcell/light/tasks/deploy-skeletal.yml
+          params:
+            SSH_PRIVATE_KEY: {{ssh_private_key}}
+            GCE_CREDENTIALS_JSON: {{gce_credentials_json}}
 
         - put: bosh-ubuntu-light-stemcells
           params:
             file: light-stemcell/light-bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent.tgz
             predefined_acl: "publicRead"
 
-        - put: bosh-ubuntu-raw-stemcells-sha1
+        - task: publish-boshio-checksum
+          file: bosh-cpi-src/ci/stemcell/light/tasks/publish-boshio-checksum.yml
           params:
-            file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
-            predefined_acl: "publicRead"
+            BOSHIO_TOKEN: {{google_boshio_checksum_token}}
 
-        - put: bosh-ubuntu-light-stemcells-sha1
-          params:
-            file: light-stemcell/light-bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent.tgz.sha1
-            predefined_acl: "publicRead"
-
-  - name: centos-7-stemcell
-    plan:
-      - aggregate:
-        - {trigger: true, get: stemcell, resource: centos-stemcells}
-        - {trigger: false, get: bosh-cpi-src}
-
-      - task: create-light-stemcell
-        file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
-        privileged: true
-        params:
-          BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
-          BOSHIO_TOKEN:    {{google_boshio_checksum_token}}
-
-      - aggregate:
-        - put: bosh-centos-raw-stemcells
-          params:
-            file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw.tar.gz
-            predefined_acl: "publicRead"
-
-        - put: bosh-centos-light-stemcells
-          params:
-            file: light-stemcell/light-bosh-stemcell-*-google-kvm-centos-7-go_agent.tgz
-            predefined_acl: "publicRead"
-
-        - put: bosh-centos-raw-stemcells-sha1
-          params:
-            file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw.tar.gz.sha1
-            predefined_acl: "publicRead"
-
-        - put: bosh-centos-light-stemcells-sha1
-          params:
-            file: light-stemcell/light-bosh-stemcell-*-google-kvm-centos-7-go_agent.tgz.sha1
-            predefined_acl: "publicRead"
+        ensure:
+          task: destroy-skeletal
+          file: bosh-cpi-src/ci/stemcell/light/tasks/destroy-skeletal.yml
+          ensure:
+            put: terraform
+            params:
+              env_name_file: terraform/name
+              terraform_source: bosh-cpi-src/ci/stemcell/light/terraform/
+              action: destroy
+            get_params:
+              action: destroy
 
 resources:
+  - name: bosh-cli
+    type: s3
+    source:
+      bucket: bosh-cli-artifacts
+      regexp: bosh-cli-(\d+\.\d+\.\d+)-linux-amd64
+
+  - name: bosh-cpi-release
+    type: bosh-io-release
+    source:
+      repository: cloudfoundry-incubator/bosh-google-cpi-release
+
   - name: bosh-cpi-src
     type: git
     source:
       uri: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release.git
       branch: master
 
-  - name: ubuntu-stemcells
-    type: s3
+  - name: terraform
+    type: terraform
     source:
-      regexp: bosh-stemcell-(.+)-google-kvm-ubuntu-trusty-go_agent.tgz
-      bucket: bosh-google-stemcells-dev
+      storage:
+        bucket: {{terraform_bucket_name}}
+        bucket_path: stemcell-ci-terraform/
+        access_key_id: {{terraform_bucket_access_key}}
+        secret_access_key: {{terraform_bucket_secret_key}}
+        endpoint: storage.googleapis.com
+      vars:
+        gce_project_id: {{gce_project_id}}
+        gce_credentials_json: {{gce_credentials_json}}
+
+  - name: ubuntu-stemcells
+    type: bosh-io-pr-force-regular
+    source:
+      name: bosh-google-kvm-ubuntu-trusty-go_agent
+      force_regular: true
 
   - name: bosh-ubuntu-raw-stemcells
     type: gcs-resource
     source:
-      json_key: {{google_raw_stemcells_json_key_data}}
+      json_key: {{gce_credentials_json}}
       bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
 
   - name: bosh-ubuntu-raw-stemcells-sha1
     type: gcs-resource
     source:
-      json_key: {{google_raw_stemcells_json_key_data}}
+      json_key: {{gce_credentials_json}}
       bucket:   {{google_raw_stemcells_bucket_name}}
       regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
 
@@ -121,48 +140,18 @@ resources:
       region:            {{google_light_stemcells_region}}
       regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-ubuntu-trusty-go_agent.tgz.sha1
 
-  - name: centos-stemcells
-    type: s3
-    source:
-      regexp: bosh-stemcell-(.+)-google-kvm-centos-7-go_agent.tgz
-      bucket: bosh-google-stemcells-dev
-
-  - name: bosh-centos-raw-stemcells
-    type: gcs-resource
-    source:
-      json_key: {{google_raw_stemcells_json_key_data}}
-      bucket:   {{google_raw_stemcells_bucket_name}}
-      regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent-raw.tar.gz
-
-  - name: bosh-centos-raw-stemcells-sha1
-    type: gcs-resource
-    source:
-      json_key: {{google_raw_stemcells_json_key_data}}
-      bucket:   {{google_raw_stemcells_bucket_name}}
-      regexp:   bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent-raw.tar.gz.sha1
-
-  - name: bosh-centos-light-stemcells
-    type: s3
-    source:
-      bucket:            {{google_light_stemcells_bucket_name}}
-      access_key_id:     {{google_light_stemcells_access_key_id}}
-      secret_access_key: {{google_light_stemcells_secret_access_key}}
-      endpoint:          {{google_light_stemcells_endpoint}}
-      region:            {{google_light_stemcells_region}}
-      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz
-
-  - name: bosh-centos-light-stemcells-sha1
-    type: s3
-    source:
-      bucket:            {{google_light_stemcells_bucket_name}}
-      access_key_id:     {{google_light_stemcells_access_key_id}}
-      secret_access_key: {{google_light_stemcells_secret_access_key}}
-      endpoint:          {{google_light_stemcells_endpoint}}
-      region:            {{google_light_stemcells_region}}
-      regexp:            light-bosh-stemcell-([0-9\.]+)-google-kvm-centos-7-go_agent.tgz.sha1
-
 resource_types:
   - name: gcs-resource
     type: docker-image
     source:
       repository: frodenas/gcs-resource
+  # TODO: remove this image once resource PR is merged
+  # https://www.pivotaltracker.com/story/show/130877947
+  - name: bosh-io-pr-force-regular
+    type: docker-image
+    source:
+      repository: boshcpi/bosh-io-pr-force-regular
+  - name: terraform
+    type: docker-image
+    source:
+      repository: ljfranklin/terraform-resource

--- a/ci/stemcell/light/skeletal-deployment.yml
+++ b/ci/stemcell/light/skeletal-deployment.yml
@@ -1,0 +1,72 @@
+---
+name: skeletal-gce
+
+releases:
+- name: bosh-google-cpi
+  url: file://assets/cpi.tgz
+
+resource_pools:
+- name: vms
+  network: private
+  stemcell:
+    url: file://assets/stemcell.tgz
+  cloud_properties:
+    machine_type: f1-micro
+    root_disk_type: pd-standard
+    zone: ((gce_zone))
+    tags:
+    - ((skeletal_firewall_tag))
+
+disk_pools:
+- name: disks
+  disk_size: 1_000
+  cloud_properties: {type: pd-standard} # 4x cheaper than pd-ssd
+
+networks:
+- name: private
+  type: dynamic
+  cloud_properties:
+    network_name: ((network_name))
+    subnetwork_name: ((subnetwork_name))
+- name: public
+  type: vip
+
+instance_groups:
+- name: skeletal
+  instances: 1
+
+  jobs: []
+
+  resource_pool: vms
+  persistent_disk_pool: disks
+
+  networks:
+  - name: private
+    default: [dns, gateway]
+  - name: public
+    static_ips: [ ((skeletal_external_ip)) ]
+
+  properties:
+    google: &google_properties
+      project: ((gce_project_id))
+      json_key: ((gce_credentials_json))
+      default_zone: ((gce_zone))
+
+    ntp: &ntp [169.254.169.254]
+
+cloud_provider:
+  template: {name: google_cpi, release: bosh-google-cpi}
+
+  ssh_tunnel:
+    host: ((skeletal_external_ip))
+    port: 22
+    user: vcap
+    private_key: ((ssh_private_key))
+
+  mbus: ((gce_cloud_provider_mbus))
+
+  properties:
+    google: *google_properties
+    agent: {mbus: ((gce_cloud_provider_agent_mbus)) }
+    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
+    ntp: *ntp

--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -e
+set -eux
 
 : ${BUCKET_NAME:?}
 : ${BOSHIO_TOKEN:=""}
@@ -32,15 +32,4 @@ pushd working_dir
 
   light_stemcell_path="${light_stemcell_dir}/${light_stemcell_name}"
   tar czvf "${light_stemcell_path}" *
-
-  checksum="$(sha1sum ${light_stemcell_path} | awk '{print $1}')"
-  echo -n "${checksum}" > ${light_stemcell_path}.sha1
-
-  if [ -n "${BOSHIO_TOKEN}" ]; then
-    curl -X POST \
-      --fail \
-      -d "sha1=${checksum}" \
-      -H "Authorization: bearer ${BOSHIO_TOKEN}" \
-      "https://bosh.io/checksums/${light_stemcell_name}"
-  fi
 popd

--- a/ci/stemcell/light/tasks/build-light-stemcell.yml
+++ b/ci/stemcell/light/tasks/build-light-stemcell.yml
@@ -16,4 +16,3 @@ run:
 
 params:
   BUCKET_NAME:  ""
-  BOSHIO_TOKEN: ""

--- a/ci/stemcell/light/tasks/deploy-skeletal.sh
+++ b/ci/stemcell/light/tasks/deploy-skeletal.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+set -ex
+
+src_dir="$( cd "$( dirname "$0" )" && cd ../../../.. && pwd )"
+workspace_dir="$( cd "${src_dir}/.." && pwd )"
+
+# env
+: ${SSH_PRIVATE_KEY:?}
+: ${GCE_CREDENTIALS_JSON:?}
+
+# inputs
+bosh_cli=$( echo ${workspace_dir}/bosh-cli/bosh-cli-* )
+chmod +x "${bosh_cli}"
+cpi_dir="$( cd "${workspace_dir}/bosh-cpi-release" && pwd )"
+stemcell_dir="$( cd "${workspace_dir}/light-stemcell" && pwd )"
+terraform_config="$( cd "${workspace_dir}/terraform" && pwd )"
+
+# outputs
+output_dir="$( cd "${workspace_dir}/deployment-state" && pwd )"
+
+mkdir -p "${output_dir}/assets/"
+cp ${cpi_dir}/*.tgz "${output_dir}/assets/cpi.tgz"
+cp ${stemcell_dir}/*.tgz "${output_dir}/assets/stemcell.tgz"
+cp ${bosh_cli} "${output_dir}/assets/bosh"
+
+# make ruby available for BOSH CLI template rendering
+source /etc/profile.d/chruby.sh
+chruby ruby-2.1.2
+
+mbus_password="$(openssl rand -base64 24 | tr -d '[/+]')"
+gce_cloud_provider_mbus="https://mbus:${mbus_password}@$(jq -r -e .skeletal_external_ip ${terraform_config}/metadata):6868"
+gce_cloud_provider_agent_mbus="https://mbus:${mbus_password}@0.0.0.0:6868"
+
+pushd "${output_dir}" > /dev/null
+  echo "Deploying skeletal instance..."
+
+  echo "${SSH_PRIVATE_KEY}" > bosh.pem # CLI has trouble with newlines in variable
+
+  ${bosh_cli} -n build-manifest \
+    -v gce_cloud_provider_mbus="${gce_cloud_provider_mbus}" \
+    -v gce_cloud_provider_agent_mbus="${gce_cloud_provider_agent_mbus}" \
+    -v gce_credentials_json="'${GCE_CREDENTIALS_JSON}'" \
+    -v ssh_private_key="bosh.pem" \
+    -l "${terraform_config}/metadata" \
+    "${src_dir}/ci/stemcell/light/skeletal-deployment.yml" > ./skeletal-deployment.yml
+
+  ${bosh_cli} -n create-env ./skeletal-deployment.yml
+popd > /dev/null
+
+echo "Successfully deployed!"

--- a/ci/stemcell/light/tasks/deploy-skeletal.yml
+++ b/ci/stemcell/light/tasks/deploy-skeletal.yml
@@ -1,0 +1,25 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/gce-cpi-release
+    tag: v2
+
+inputs:
+  - name: bosh-cli
+  - name: bosh-cpi-release
+  - name: bosh-cpi-src
+  - name: light-stemcell
+  - name: terraform
+
+outputs:
+  - name: deployment-state
+
+run:
+  path: bosh-cpi-src/ci/stemcell/light/tasks/deploy-skeletal.sh
+
+params:
+  SSH_PRIVATE_KEY:      ""
+  GCE_CREDENTIALS_JSON: ""

--- a/ci/stemcell/light/tasks/destroy-skeletal.sh
+++ b/ci/stemcell/light/tasks/destroy-skeletal.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -ex
+
+src_dir="$( cd "$( dirname "$0" )" && cd ../../../.. && pwd )"
+workspace_dir="$( cd "${src_dir}/.." && pwd )"
+
+# inputs
+deployment_state="$( cd "${workspace_dir}/deployment-state" && pwd )"
+
+# make ruby available for BOSH CLI template rendering
+source /etc/profile.d/chruby.sh
+chruby ruby-2.1.2
+
+pushd "${deployment_state}" > /dev/null
+  echo "Destroying skeletal instance..."
+
+  set +e
+  ./assets/bosh -n delete-env ./skeletal-deployment.yml
+  exit_code=$?
+  set -e
+
+  if [ "${exit_code}" == "0" ]; then
+    echo "Successfully destroyed!"
+  else
+    echo "Failed to destroy deployment, continuing..."
+  fi
+
+popd > /dev/null

--- a/ci/stemcell/light/tasks/destroy-skeletal.yml
+++ b/ci/stemcell/light/tasks/destroy-skeletal.yml
@@ -1,0 +1,15 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/gce-cpi-release
+    tag: v2
+
+inputs:
+  - name: deployment-state
+  - name: bosh-cpi-src
+
+run:
+  path: bosh-cpi-src/ci/stemcell/light/tasks/destroy-skeletal.sh

--- a/ci/stemcell/light/tasks/publish-boshio-checksum.sh
+++ b/ci/stemcell/light/tasks/publish-boshio-checksum.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eux
+
+: ${BOSHIO_TOKEN:=""}
+
+# inputs
+light_stemcell_dir="$PWD/light-stemcell"
+
+if [ -n "${BOSHIO_TOKEN}" ]; then
+  light_stemcell_path="$(echo ${light_stemcell_dir}/*.tgz)"
+  light_stemcell_name="$(basename "${light_stemcell_path}")"
+
+  echo "Publishing light stemcell checksum to bosh.io"
+
+  checksum="$(sha1sum ${light_stemcell_dir}/*.tgz | awk '{print $1}')"
+
+  curl -X POST \
+    --fail \
+    -d "sha1=${checksum}" \
+    -H "Authorization: bearer ${BOSHIO_TOKEN}" \
+    "https://bosh.io/checksums/${light_stemcell_name}"
+
+  echo "Successfully published checksum!"
+else
+  echo "Checksum not provided, skipping publish checksum."
+fi

--- a/ci/stemcell/light/tasks/publish-boshio-checksum.yml
+++ b/ci/stemcell/light/tasks/publish-boshio-checksum.yml
@@ -1,0 +1,18 @@
+---
+platform: linux
+
+image_resource:
+  type: docker-image
+  source:
+    repository: boshcpi/gce-cpi-release
+    tag: v2
+
+inputs:
+  - name: light-stemcell
+  - name: bosh-cpi-src
+
+run:
+  path: bosh-cpi-src/ci/stemcell/light/tasks/publish-boshio-checksum.sh
+
+params:
+  BOSHIO_TOKEN: ""

--- a/ci/stemcell/light/terraform/input.tf
+++ b/ci/stemcell/light/terraform/input.tf
@@ -1,0 +1,22 @@
+variable "gce_project_id" {
+  type = "string"
+}
+
+variable "gce_credentials_json" {
+  type = "string"
+}
+
+variable "gce_region" {
+  type = "string"
+  default = "us-central1"
+}
+
+variable "gce_zone" {
+  type = "string"
+  default = "us-central1-f"
+}
+
+variable "env_name" {
+  type = "string"
+}
+

--- a/ci/stemcell/light/terraform/output.tf
+++ b/ci/stemcell/light/terraform/output.tf
@@ -1,0 +1,27 @@
+output "gce_project_id" {
+  value = "${var.gce_project_id}"
+}
+
+output "gce_region" {
+  value = "${var.gce_region}"
+}
+
+output "gce_zone" {
+  value = "${var.gce_zone}"
+}
+
+output "network_name" {
+  value = "${google_compute_network.skeletal.name}"
+}
+
+output "subnetwork_name" {
+  value = "${google_compute_subnetwork.skeletal.name}"
+}
+
+output "skeletal_external_ip" {
+  value = "${google_compute_address.skeletal.address}"
+}
+
+output "skeletal_firewall_tag" {
+  value = "skeletal-external-${var.env_name}"
+}

--- a/ci/stemcell/light/terraform/skeletal.tf
+++ b/ci/stemcell/light/terraform/skeletal.tf
@@ -1,0 +1,37 @@
+provider "google" {
+    project = "${var.gce_project_id}"
+    region = "${var.gce_region}"
+    credentials = "${var.gce_credentials_json}"
+}
+
+resource "google_compute_network" "skeletal" {
+  name = "stemcell-ci-${var.env_name}"
+}
+
+// Subnet for the skeletal deployment
+resource "google_compute_subnetwork" "skeletal" {
+  name          = "stemcell-ci-${var.env_name}"
+  ip_cidr_range = "10.0.0.0/24"
+  network       = "${google_compute_network.skeletal.self_link}"
+}
+
+// Allow SSH & MBus to skeletal deployment
+resource "google_compute_firewall" "allow-ssh-mbus" {
+  name    = "allow-ssh-mbus-${var.env_name}"
+  network = "${google_compute_network.skeletal.name}"
+
+  allow {
+    protocol = "icmp"
+  }
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "6868"]
+  }
+
+  target_tags = ["skeletal-external-${var.env_name}"]
+}
+
+resource "google_compute_address" "skeletal" {
+  name = "skeletal-ip-${var.env_name}"
+}


### PR DESCRIPTION
- Pulls heavy stemcells from bosh.io
- Add task to verify stemcell boots before publishing
- Uses terraform to setup and teardown environment
- Removes CentOS jobs as we don't yet have heavy CentOS stemcells
  for GCE
- Trigger light stemcell pipeline on every stemcell version so versions
  don't get skipped
- Ensure light stemcell and checksum are published as late as possible
  - Checksums are immutable on bosh.io, so we need to run that stage last

[#130561911](https://www.pivotaltracker.com/story/show/130561911)

Signed-off-by: Lyle Franklin <lfranklin@pivotal.io>