### PR TITLE
Add Service Accounts to support StackDriver Logging

### DIFF
--- a/docs/bosh/README.md
+++ b/docs/bosh/README.md
@@ -225,15 +225,15 @@ Before working this section, you must have deployed the supporting infrastructur
       url: https://bosh.io/d/github.com/cloudfoundry/bosh?v=257.3
       sha1: e4442afcc64123e11f2b33cc2be799a0b59207d0
     - name: bosh-google-cpi
-      url: https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.1.0.tgz
-      sha1: f99dff6860731921282dd1bcd097a74beaeb72a4
+      url: https://bosh.io/d/github.com/cloudfoundry-incubator/bosh-google-cpi-release?v=25.4.1
+      sha1: 7761d8eb48c2a2fec50f4f637ce016735ad779dc
 
   resource_pools:
     - name: vms
       network: private
       stemcell:
-        url: https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.5-google-kvm-ubuntu-trusty-go_agent.tgz
-        sha1: b7ed64f1a929b9a8e906ad5faaed73134dc68c53
+        url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3263.4
+        sha1: 0a93ba7468e7c1c543404f82bef295fbb21172f5
       cloud_properties:
         zone: {{ZONE}}
         machine_type: n1-standard-4

--- a/docs/bosh/README.md
+++ b/docs/bosh/README.md
@@ -232,7 +232,7 @@ Before working this section, you must have deployed the supporting infrastructur
     - name: vms
       network: private
       stemcell:
-        url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3263.4
+        url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3262.19
         sha1: 0a93ba7468e7c1c543404f82bef295fbb21172f5
       cloud_properties:
         zone: {{ZONE}}

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -212,7 +212,7 @@ Before working this section, you must have deployed the supporting infrastructur
 1. Upload the required [Google BOSH Stemcell](http://bosh.io/docs/stemcell.html):
 
   ```
-  bosh upload stemcell https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.12-google-kvm-ubuntu-trusty-go_agent.tgz
+  bosh upload stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3263.4
   ```
 
 1. Upload the required [BOSH Releases](http://bosh.io/docs/release.html):

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -212,7 +212,7 @@ Before working this section, you must have deployed the supporting infrastructur
 1. Upload the required [Google BOSH Stemcell](http://bosh.io/docs/stemcell.html):
 
   ```
-  bosh upload stemcell https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.5-google-kvm-ubuntu-trusty-go_agent.tgz
+  bosh upload stemcell https://storage.googleapis.com/bosh-cpi-artifacts/light-bosh-stemcell-3262.12-google-kvm-ubuntu-trusty-go_agent.tgz
   ```
 
 1. Upload the required [BOSH Releases](http://bosh.io/docs/release.html):

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -48,6 +48,25 @@ You must have followed the [Deploy supporting infrastructure automatically](../b
   terraform apply -var projectid=${projectid} -var region=${region} -var zone=${zone}
   ```
 
+1. Create a service account and key:
+
+  ```
+  gcloud iam service-accounts create cf-component
+  gcloud iam service-accounts keys create /tmp/cf-component.key.json \
+      --iam-account cf-component@${projectid}.iam.gserviceaccount.com
+  ```
+
+1. Grant the new service account editor access and logging access to your project:
+
+  ```
+  gcloud projects add-iam-policy-binding ${projectid} \
+      --member serviceAccount:cf-component@${projectid}.iam.gserviceaccount.com \
+      --role "roles/editor" \
+      --role "roles/logging.logWriter" \
+      --role "roles/logging.configWriter"
+  ```
+
+
 Now you have the infrastructure ready to deploy Cloud Foundry. Go ahead to the [Deploy Cloud Foundry](#deploy-cloudfoundry) section to do that. 
 
 <a name="deploy-manually"></a>
@@ -213,6 +232,7 @@ Before working this section, you must have deployed the supporting infrastructur
   sed -i s#{{DIRECTOR_UUID}}#`bosh status --uuid 2>/dev/null`# cloudfoundry.yml
   sed -i s#{{REGION}}#$region# cloudfoundry.yml
   sed -i s#{{ZONE}}#$zone# cloudfoundry.yml
+  sed -i s#{{PROJECT_ID}}#$projectid# cloudfoundry.yml
   ```
 
 1. Target the deployment file and deploy:

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -28,9 +28,10 @@ You must have followed the [Deploy supporting infrastructure automatically](../b
 ### Steps
 1. Download the Cloud Foundry Terraform file - [cloudfoundry.tf](cloudfoundry.tf) - and save it to the same directory where you saved the BOSH director's `main.tf` file.
 
-1. Export your preferred region and zone (you may skip this if already set from the previous BOSH deployment instructions)
+1. Export your project id, preferred region, and zone (you may skip this if already set from the previous BOSH deployment instructions)
 
   ```
+  export projectid=REPLACE_WITH_YOUR_PROJECT_ID
   export region=us-east1
   export zone=us-east1-d
   ```
@@ -38,13 +39,13 @@ You must have followed the [Deploy supporting infrastructure automatically](../b
 1. Use Terraform's `plan` feature to confirm that the new resources will be created:
 
   ```
-  terraform plan -var region=${region} -var zone=${zone}
+  terraform plan -var projectid=${projectid} -var region=${region} -var zone=${zone}
   ```
 
 1. Create the resources
 
   ```
-  terraform apply -var region=${region} -var zone=${zone}
+  terraform apply -var projectid=${projectid} -var region=${region} -var zone=${zone}
   ```
 
 Now you have the infrastructure ready to deploy Cloud Foundry. Go ahead to the [Deploy Cloud Foundry](#deploy-cloudfoundry) section to do that. 
@@ -208,10 +209,10 @@ Before working this section, you must have deployed the supporting infrastructur
 1. Download the [cloudfoundry.yml](cloudfoundry.yml) deployment manifest file and use `sed` to modify a few values in it:
 
   ```
-  $ sed -i s#{{VIP_IP}}#`gcloud compute addresses describe cf | grep ^address: | cut -f2 -d' '`# cloudfoundry.yml
-  $ sed -i s#{{DIRECTOR_UUID}}#`bosh status --uuid 2>/dev/null`# cloudfoundry.yml
-  $ sed -i s#{{REGION}}#$region# cloudfoundry.yml
-  sed -i s#{{ZONE}}#zone# cloudfoundry.yml
+  sed -i s#{{VIP_IP}}#`gcloud compute addresses describe cf | grep ^address: | cut -f2 -d' '`# cloudfoundry.yml
+  sed -i s#{{DIRECTOR_UUID}}#`bosh status --uuid 2>/dev/null`# cloudfoundry.yml
+  sed -i s#{{REGION}}#$region# cloudfoundry.yml
+  sed -i s#{{ZONE}}#$zone# cloudfoundry.yml
   ```
 
 1. Target the deployment file and deploy:

--- a/docs/cloudfoundry/README.md
+++ b/docs/cloudfoundry/README.md
@@ -212,7 +212,7 @@ Before working this section, you must have deployed the supporting infrastructur
 1. Upload the required [Google BOSH Stemcell](http://bosh.io/docs/stemcell.html):
 
   ```
-  bosh upload stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3263.4
+  bosh upload stemcell https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3262.19
   ```
 
 1. Upload the required [BOSH Releases](http://bosh.io/docs/release.html):

--- a/docs/cloudfoundry/cloudfoundry.yml
+++ b/docs/cloudfoundry/cloudfoundry.yml
@@ -88,8 +88,6 @@ compilation:
     root_disk_type: pd-ssd
     preemptible: true
     service_account: <%= cf_service_account%>
-    service_scopes:
-      - cloud-platform
 
 update:
   canaries: 1
@@ -143,8 +141,6 @@ resource_pools:
       root_disk_size_gb: 20
       root_disk_type: pd-standard
       service_account: <%= cf_service_account%>
-      service_scopes:
-        - cloud-platform
 
   - name: common-public
     network: public
@@ -158,8 +154,6 @@ resource_pools:
       root_disk_type: pd-standard
       target_pool: cf-public
       service_account: <%= cf_service_account%>
-      service_scopes:
-        - cloud-platform
 
   - name: cells
     network: private
@@ -172,8 +166,6 @@ resource_pools:
       root_disk_size_gb: 100
       root_disk_type: pd-standard
       service_account: <%= cf_service_account%>
-      service_scopes:
-        - cloud-platform
 
 disk_pools:
   - name: consul

--- a/docs/cloudfoundry/cloudfoundry.yml
+++ b/docs/cloudfoundry/cloudfoundry.yml
@@ -13,6 +13,12 @@ google_zone = "{{ZONE}}"
 network = "cf"
 public_subnetwork = "cf-public-#{google_region}"
 private_subnetwork = "cf-private-#{google_region}"
+
+# Google service account settings
+project_id = "{{PROJECT_ID}}"
+org, project = project_id.split(":")
+project_domain_prefix = [project, org].compact.join(".")
+cf_service_account = "cf-component@#{project_domain_prefix}.iam.gserviceaccount.com"
 %>
 ssl_cert: &ssl_cert |
   -----BEGIN CERTIFICATE-----
@@ -81,6 +87,9 @@ compilation:
     root_disk_size_gb: 100
     root_disk_type: pd-ssd
     preemptible: true
+    service_account: <%= cf_service_account%>
+    service_scopes:
+      - cloud-platform
 
 update:
   canaries: 1
@@ -133,6 +142,9 @@ resource_pools:
       machine_type: n1-standard-4
       root_disk_size_gb: 20
       root_disk_type: pd-standard
+      service_account: <%= cf_service_account%>
+      service_scopes:
+        - cloud-platform
 
   - name: common-public
     network: public
@@ -145,6 +157,9 @@ resource_pools:
       root_disk_size_gb: 20
       root_disk_type: pd-standard
       target_pool: cf-public
+      service_account: <%= cf_service_account%>
+      service_scopes:
+        - cloud-platform
 
   - name: cells
     network: private
@@ -156,6 +171,9 @@ resource_pools:
       machine_type: n1-highmem-8
       root_disk_size_gb: 100
       root_disk_type: pd-standard
+      service_account: <%= cf_service_account%>
+      service_scopes:
+        - cloud-platform
 
 disk_pools:
   - name: consul


### PR DESCRIPTION
Docs cleanup:
 - Add project id var for consistency (needed by terraform)
 - Fix sed commands
 - Referenced stemcell version won't deploy CF

Service Account:
 - Add a 'cf-component' service account as part of the setup
 - Apply this SA to each pool in the deployment
 - This account has the default access (editor) and the needed access for StackDriver