### PR TITLE
Updates the Google Cloud SDK on the bastion

### DIFF
--- a/docs/bosh/README.md
+++ b/docs/bosh/README.md
@@ -104,6 +104,12 @@ Before working this section, you must have deployed the supporting infrastructur
   gcloud compute ssh bosh-bastion
   ```
 
+1. Once on the VM, update its Google Cloud SDK to the latest:
+
+  ```
+  sudo gcloud components update
+  ```
+
 1. Configure `gcloud` to use the correct zone and region:
 
   ```


### PR DESCRIPTION
Updates Bosh README to include updating the Google Cloud SDK on the bastion.

Before:

```
dwayne.forde@bosh-bastion:~$ gcloud config set compute/zone ${zone}


Updates are available for some Cloud SDK components.  To install them,
please run:
  $ gcloud components update
```

After:

```
dwayne.forde@bosh-bastion:~$ gcloud config set compute/zone ${zone}
Updated property [compute/zone].
```
