### PR TITLE
link to release tarballs on bosh.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,29 +3,9 @@
 This is a [BOSH](http://bosh.io/) release for the BOSH Google CPI.
 
 ## Releases
-Please see [CHANGELOG.md] for details of each release.
-<!--The Releases section is automatically generated. Do not edit-->
-### CPI
-
-|Version|SHA1|Date|
-|---|---|---|
-|[24.0.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.tgz)|e2f77a0a8696b29fdb676cf447cfd9bc6841b648|2016-07-22|
-|[24.1.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.1.0.tgz)|dda781faa6673430ce77d708ac1c4be3cb763886|2016-07-25|
-|[24.2.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.2.0.tgz)|80d3ef039cb0ed014e97eeea10569598804659d3|2016-07-26|
-|[24.3.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.3.0.tgz)|f62cebd284d682121a5b4075d0c60a47dd3981ca|2016-07-27|
-|[24.4.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-24.4.0.tgz)|0c8c8efc316e5d1e0b2e4665b88dfb044b4b87a3|2016-08-10|
-|[25.0.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.0.0.tgz)|701874022ea1d17e7cf2d829fde166aaacbdd1ed|2016-08-14|
-|[25.1.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.1.0.tgz)|f99dff6860731921282dd1bcd097a74beaeb72a4|2016-08-18|
-|[25.2.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.2.0.tgz)|6918d9acb7d4dcb3254bae9ad92920c0e360eef4|2016-08-25|
-|[25.2.1](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.2.1.tgz)|7dde4c0ea5d49ea681fd04c2d0595afb3660fab9|2016-08-29|
-|[25.3.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.3.0.tgz)|69fb68b28937681203316f82e2765b0c9925ae01|2016-09-07|
-|[25.4.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.4.0.tgz)|662677c9013b41820381e60ad1230d5eadd7b713|2016-09-15|
-|[25.4.1](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.4.1.tgz)|4dbc5c9611724eb270b510b96d5cbde9052f9c31|2016-09-22|
-|[25.5.0](https://storage.googleapis.com/bosh-cpi-artifacts/bosh-google-cpi-25.5.0.tgz)|9cbb0e6c0ca8b38bcec449af42a7c0a09f2475ad|2016-10-18|
-[//]: # (new-cpi)
+Releases are available on bosh.io: [https://bosh.io/releases/github.com/cloudfoundry-incubator/bosh-google-cpi-release?all=1](https://bosh.io/releases/github.com/cloudfoundry-incubator/bosh-google-cpi-release?all=1). Please see [CHANGELOG.md] for details of each release.
 
 ### Stemcell
-
 Stemcells are available on bosh.io: [http://bosh.io/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent](http://bosh.io/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent)
 
 ## Usage
@@ -33,7 +13,6 @@ If you are not familiar with [BOSH](http://bosh.io/) and its terminology please 
 
 ## Deploy a BOSH Director on Google Cloud Platform
 Complete instructions for deploying a BOSH Director are available in the [docs/bosh/README.md](docs/bosh/README.md) file.
-
 
 ## Deploy other software
 After you have followed the instructions for deploying a BOSH director in [docs/bosh/README.md](docs/bosh/README.md), you may deploy releases like CloudFoundry by following the links below:


### PR DESCRIPTION
It would also be nice to have release notes in https://github.com/cloudfoundry-incubator/bosh-google-cpi-release/releases tab (they'll show up on bosh.io next to each version as well).
