### PR TITLE
Remove 'apt-get upgrade' from Concourse main.tf

### DIFF
--- a/docs/concourse/main.tf
+++ b/docs/concourse/main.tf
@@ -98,7 +98,6 @@ resource "google_compute_instance" "bosh-bastion" {
   metadata_startup_script = <<EOT
 #!/bin/bash
 apt-get update -y
-apt-get upgrade -y
 apt-get install -y build-essential zlibc zlib1g-dev ruby ruby-dev openssl libxslt-dev libxml2-dev libssl-dev libreadline6 libreadline6-dev libyaml-dev libsqlite3-dev sqlite3
 gem install bosh_cli
 curl -o /tmp/cf.tgz https://s3.amazonaws.com/go-cli/releases/v6.20.0/cf-cli_6.20.0_linux_x86-64.tgz


### PR DESCRIPTION
- Related to changes made in #1884962a3cc6165dc3fa043880847ada389f86b3