### PR TITLE
use correct sha1 on light stemcells

### DIFF
--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -28,6 +28,8 @@ pushd working_dir
   echo -n $(sha1sum ${raw_stemcell_path} | awk '{print $1}') > ${raw_stemcell_path}.sha1
 
   > image
+  light_stemcell_sha1=$(sha1sum image | awk '{print $1}')
+  sed -i '/^sha1: .*/c\sha1: '${light_stemcell_sha1}'' stemcell.MF
   echo "  source_url: https://storage.googleapis.com/${BUCKET_NAME}/${raw_stemcell_name}" >> stemcell.MF
 
   light_stemcell_path="${light_stemcell_dir}/${light_stemcell_name}"


### PR DESCRIPTION
As of now light stemcell have the raw stemcell sha1. It should have the sha1 of the `image` file contained in the light-*.tgz

[#134451441](https://www.pivotaltracker.com/story/show/134451441)

Signed-off-by: Chris Hajas <chajas@pivotal.io>