### PR TITLE
setup load balancer for websocket on concourse

### DIFF
--- a/docs/concourse/concourse.tf
+++ b/docs/concourse/concourse.tf
@@ -1,31 +1,28 @@
-// Subnet for the public Concourse components
 resource "google_compute_subnetwork" "concourse-public-subnet-1" {
   name          = "concourse-public-${var.region}-1"
   ip_cidr_range = "10.150.0.0/16"
   network       = "${google_compute_network.network.self_link}"
 }
 
-// Subnet for the public Concourse components
 resource "google_compute_subnetwork" "concourse-public-subnet-2" {
   name          = "concourse-public-${var.region}-2"
   ip_cidr_range = "10.160.0.0/16"
   network       = "${google_compute_network.network.self_link}"
 }
 
-// Allow access to CloudFoundry router
 resource "google_compute_firewall" "concourse-public" {
   name    = "concourse-public"
   network = "${google_compute_network.network.name}"
 
   allow {
     protocol = "tcp"
-    ports    = ["8080"]
+    ports    = ["80", "8080", "443", "4443"]
   }
+  source_ranges = ["0.0.0.0/0"]
 
   target_tags = ["concourse-public"]
 }
 
-// Allow open access to between internal VMs
 resource "google_compute_firewall" "concourse-internal" {
   name    = "concourse-internal"
   network = "${google_compute_network.network.name}"
@@ -46,70 +43,26 @@ resource "google_compute_firewall" "concourse-internal" {
   source_tags = ["concourse-internal", "bosh-internal"]
 }
 
-// Static IP address for forwarding rule
-resource "google_compute_global_address" "concourse" {
+resource "google_compute_address" "concourse" {
   name = "concourse"
 }
 
-// Instance group 1
-resource "google_compute_instance_group" "concourse-1" {
-  name        = "concourse-${var.zone-1}-1"
-  zone        = "${var.zone-1}"
-  named_port {
-    name = "http"
-    port = "8080"
-  }
+resource "google_compute_target_pool" "concourse-target-pool" {
+  name = "concourse-target-pool"
 }
 
-// Instance group 2
-resource "google_compute_instance_group" "concourse-2" {
-  name        = "concourse-${var.zone-2}-2"
-  zone        = "${var.zone-2}"
-  named_port {
-    name = "http"
-    port = "8080"
-  }
+resource "google_compute_forwarding_rule" "concourse-http-forwarding-rule" {
+  name        = "concourse-http-forwarding-rule"
+  target      = "${google_compute_target_pool.concourse-target-pool.self_link}"
+  port_range  = "80-80"
+  ip_protocol = "TCP"
+  ip_address  = "${google_compute_address.concourse.address}"
 }
 
-resource "google_compute_backend_service" "concourse" {
-  name        = "concourse"
-  port_name   = "http"
-  protocol    = "HTTP"
-  timeout_sec = 10
-  enable_cdn  = false
-
-  backend {
-    group = "${google_compute_instance_group.concourse-1.self_link}"
-  }
-  backend {
-    group = "${google_compute_instance_group.concourse-2.self_link}"
-  }
-
-  health_checks = ["${google_compute_http_health_check.concourse.self_link}"]
-}
-
-resource "google_compute_http_health_check" "concourse" {
-  name               = "concourse"
-  request_path       = "/login"
-  check_interval_sec = 1
-  timeout_sec        = 1
-  port               = 8080
-}
-
-resource "google_compute_target_http_proxy" "concourse" {
-  name             = "concourse"
-  url_map          = "${google_compute_url_map.concourse.self_link}"
-}
-
-resource "google_compute_url_map" "concourse" {
-  name        = "concourse"
-
-  default_service = "${google_compute_backend_service.concourse.self_link}"
-}
-
-resource "google_compute_global_forwarding_rule" "concourse" {
-  name       = "concourse"
-  ip_address    = "${google_compute_global_address.concourse.address}"
-  target     = "${google_compute_target_http_proxy.concourse.self_link}"
-  port_range = "80"
+resource "google_compute_forwarding_rule" "concourse-https-forwarding-rule" {
+  name        = "concourse-https-forwarding-rule"
+  target      = "${google_compute_target_pool.concourse-target-pool.self_link}"
+  port_range  = "443-443"
+  ip_protocol = "TCP"
+  ip_address  = "${google_compute_address.concourse.address}"
 }

--- a/docs/concourse/concourse.yml
+++ b/docs/concourse/concourse.yml
@@ -36,6 +36,7 @@ instance_groups:
   - name: atc
     release: concourse
     properties:
+      bind_port: 80
       external_url: <%= external_url %>
       basic_auth_username: concourse
       basic_auth_password: <%= atc_password %>


### PR DESCRIPTION
The load balancer setup for concourse does not support Websockets, so things like `fly hijack` don't work. This corrects the terraform to fix the load balancing issue.

A side note, since LBs don't support port forwarding, concourse `atc` has to run on port 80.

Signed-off-by: Robert Sullivan <rsullivan@pivotal.io>