### PR TITLE
groundcrew properties fix

### DIFF
--- a/docs/concourse/concourse.yml
+++ b/docs/concourse/concourse.yml
@@ -74,10 +74,9 @@ instance_groups:
   - name: groundcrew
     release: concourse
     properties: 
-      groundcrew:
-        additional_resource_types:
-        - type: gcs-resource
-          image: docker:///frodenas/gcs-resource
+      additional_resource_types:
+      - type: gcs-resource
+        image: docker:///frodenas/gcs-resource
   - name: baggageclaim
     release: concourse
     properties: {}


### PR DESCRIPTION
According to https://github.com/concourse/concourse/blob/master/jobs/groundcrew/spec
There is no properties that are under a `groundcrew` level