### PR TITLE
A few minor doc fixes and Trusty update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,9 @@ support for an existing issue by voting it up. When submitting a bug report, ple
 including your gem version, Ruby version, and operating system. Ideally, a bug report should include a pull request with failing specs.
 
 ## Submitting a Pull Request
+
 You can add a feature or bug-fix via pull request.
+
 1. Fork the project
 1. Create a branch for your feature or fix from the `develop` branch. Replace `your-feature-name` with a description of your feature or fix:
 

--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -1,3 +1,9 @@
+// Easier mainteance for updating GCE image string
+variable "latest_ubuntu" {
+    type = "string"
+    default = "ubuntu-1404-trusty-v20161109"
+}
+
 variable "projectid" {
     type = "string"
 }
@@ -96,7 +102,7 @@ resource "google_compute_instance" "bosh-bastion" {
   tags = ["bosh-bastion", "internal"]
 
   disk {
-    image = "ubuntu-1404-trusty-v20161020"
+    image = "${var.latest_ubuntu}"
   }
 
   network_interface {
@@ -113,14 +119,14 @@ cat > /etc/motd <<EOF
 
 
 
-#    #    ##    #####   #    #     #    #    #   ####
-#    #   #  #   #    #  ##   #     #    ##   #  #    #
-#    #  #    #  #    #  # #  #     #    # #  #  #
-# ## #  ######  #####   #  # #     #    #  # #  #  ###
-##  ##  #    #  #   #   #   ##     #    #   ##  #    #
-#    #  #    #  #    #  #    #     #    #    #   ####
+#    #     ##     #####    #    #   #   #    #    ####
+#    #    #  #    #    #   ##   #   #   ##   #   #    #
+#    #   #    #   #    #   # #  #   #   # #  #   #
+# ## #   ######   #####    #  # #   #   #  # #   #  ###
+##  ##   #    #   #   #    #   ##   #   #   ##   #    #
+#    #   #    #   #    #   #    #   #   #    #    ####
 
-Startup scripts have not finished installing, and the tools you need
+Startup scripts have not finished running, and the tools you need
 are not ready yet. Please log out and log back in again in a few moments.
 This warning will not appear when the system is ready.
 EOF
@@ -181,7 +187,7 @@ resource "google_compute_instance" "nat-instance-private-with-nat-primary" {
   tags = ["nat", "internal"]
 
   disk {
-    image = "ubuntu-1404-trusty-v20161020"
+    image = "${var.latest_ubuntu}"
   }
 
   network_interface {


### PR DESCRIPTION
Ran through a full install and made a couple of minor doc changes:

- *WARNING*: Updated the Trusty image in the terraform script (to suppress `gcloud components update` warning)
- Fixed formatting on CONTRIBUTING
- Linked to the Google Slide for architecture diagram
- Added some timing expectations for the user (and suggestion to use tmux)
- Added more delete instructions since we were "leaking resources"