### PR TITLE
Update README to fix missing project_id which fails deploy

### DIFF
--- a/docs/concourse/README.md
+++ b/docs/concourse/README.md
@@ -344,7 +344,7 @@ Complete the following steps from your bastion instance.
 1. Download the [concourse.yml](concourse.yml) manifest file and set a few environment variables:
 
   ```
-  export external_ip=`gcloud compute addresses describe concourse --global | grep ^address: | cut -f2 -d' '`
+  export external_ip=`gcloud compute addresses describe concourse | grep ^address: | cut -f2 -d' '`
   export director_uuid=`bosh status --uuid 2>/dev/null`
   ```
 

--- a/docs/concourse/README.md
+++ b/docs/concourse/README.md
@@ -132,7 +132,7 @@ This guide describes how to deploy [Concourse](http://concourse.ci/) on [Google 
   end
 
   region = ENV['region']
-  project_id = ENV['common_password']
+  project_id = ENV['project_id']
   zone = ENV['zone']
   ssh_key_path = ENV['ssh_key_path']
   %>


### PR DESCRIPTION
The Concourse set up docs need fixing to avoid a failing deployment of bosh as well as errors during the Concourse deploy prep. 

1.  The yml template (which needs to copy/pasted as part of the set up) contains ENV['common_password'] instead of ENV['project_id'].  This leads to the `bosh-init deploy` failing because the erb step leaves the manifest with an empty string for google.project. It causes the following error during a deploy `google_cpi/0 (line 7: #<TemplateEvaluationContext::UnknownProperty: Can't find property 'google.project'>) (RuntimeError)`
2. When preparing to deploy Concourse the IP is parsed, however, the `--global` flag needs to be removed as the set up is based on region. Removing the `--global` is sufficient for it to work. When `--global` is present an error is thrown `ERROR: (gcloud.compute.addresses.describe) Could not fetch resource:`