### PR TITLE
Set MTU on garden jobs

### DIFF
--- a/docs/cloudfoundry/manifest.yml
+++ b/docs/cloudfoundry/manifest.yml
@@ -694,6 +694,9 @@ jobs:
     networks:
       - name: private
         default: [dns, gateway]
+    properties:
+      garden:
+        network_mtu: 1432
 
   - name: doppler
     templates:

--- a/docs/concourse/concourse.yml
+++ b/docs/concourse/concourse.yml
@@ -87,6 +87,7 @@ instance_groups:
       garden:
         listen_network: tcp
         listen_address: 0.0.0.0:7777
+        network_mtu: 1432
 
 update:
   canaries: 1


### PR DESCRIPTION
Setting to 1432 which is the max size for UDP packets on GCP

Reference: https://cloud.google.com/compute/docs/troubleshooting#packetfragmentation

Fixes #124