### PR TITLE
Update cloud config to match the new terraform script. Concourse back…

### DIFF
--- a/docs/concourse/cloud-config.yml
+++ b/docs/concourse/cloud-config.yml
@@ -34,7 +34,7 @@ vm_types:
 vm_extensions:
 - name: concourse-lb
   cloud_properties:
-    backend_service: concourse
+    target_pool: concourse-target-pool
 
 compilation:
   workers: 2


### PR DESCRIPTION
…end service no longer exists.

On a clean install terraform, the bosh deploy fails with 'concourse-target-pool" does not exist' when creating the web vm.

Is there CI for the terraform and concourse deployment? If not I can investigate setting one up.