### PR TITLE
Update cloud config to match new concourse.tf

### DIFF
--- a/docs/concourse/cloud-config.yml
+++ b/docs/concourse/cloud-config.yml
@@ -34,7 +34,7 @@ vm_types:
 vm_extensions:
 - name: concourse-lb
   cloud_properties:
-    backend_service: concourse
+    target_pool: concourse-target-pool
 
 compilation:
   workers: 2


### PR DESCRIPTION
As of 1f63138ef17ca2e46b6ea01988ef7eece2ba5300, terraform
sets up target pools instead of backend services. The cloud
config should reference the target pool instead of the backend service.