### PR TITLE
Add ability to self image_self_link in stemcell.MF

### DIFF
--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -30,6 +30,9 @@ type StemcellCloudProperties struct {
 	Version        string `json:"version,omitempty"`
 	Infrastructure string `json:"infrastructure,omitempty"`
 	SourceURL      string `json:"source_url,omitempty"`
+
+	// URL of an existing image (Image.SelfLink)
+	ImageURL string `json:"image_url,omitempty"`
 }
 
 type VMCloudProperties struct {

--- a/src/bosh-google-cpi/action/create_stemcell.go
+++ b/src/bosh-google-cpi/action/create_stemcell.go
@@ -34,9 +34,12 @@ func (cs CreateStemcell) Run(stemcellPath string, cloudProps StemcellCloudProper
 		description = fmt.Sprintf("%s/%s", cloudProps.Name, cloudProps.Version)
 	}
 
-	if cloudProps.SourceURL != "" {
+	switch {
+	case cloudProps.ImageURL != "":
+		stemcell = cloudProps.ImageURL
+	case cloudProps.SourceURL != "":
 		stemcell, err = cs.imageService.CreateFromURL(cloudProps.SourceURL, description)
-	} else {
+	default:
 		stemcell, err = cs.imageService.CreateFromTarball(stemcellPath, description)
 	}
 	if err != nil {

--- a/src/bosh-google-cpi/action/create_stemcell_test.go
+++ b/src/bosh-google-cpi/action/create_stemcell_test.go
@@ -102,4 +102,18 @@ var _ = Describe("CreateStemcell", func() {
 			})
 		})
 	})
+
+	Context("from a image url", func() {
+		BeforeEach(func() {
+			cloudProps.ImageURL = "fake-image-url"
+		})
+
+		It("creates the stemcell", func() {
+			stemcellCID, err = createStemcell.Run("fake-stemcell-tarball", cloudProps)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageService.CreateFromTarballCalled).To(BeFalse())
+			Expect(imageService.CreateFromURLCalled).To(BeFalse())
+			Expect(stemcellCID).To(Equal(StemcellCID(cloudProps.ImageURL)))
+		})
+	})
 })

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -2,6 +2,7 @@ package action
 
 import (
 	"fmt"
+	"strings"
 
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 
@@ -184,7 +185,14 @@ func (cv CreateVM) findZone(zoneName string, disks []DiskCID) (string, error) {
 	return "", fmt.Errorf("Could not find zone %q", zoneName)
 }
 
+func isGcpImageURL(s string) bool {
+	return strings.HasPrefix(s, "https://www.googleapis.com/compute/v1/projects/")
+}
+
 func (cv CreateVM) findStemcellLink(stemcellID string) (string, error) {
+	if isGcpImageURL(stemcellID) {
+		return stemcellID, nil
+	}
 	stemcell, found, err := cv.imageService.Find(stemcellID)
 	if err != nil {
 		return "", bosherr.WrapError(err, "Creating vm")

--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -202,6 +202,14 @@ var _ = Describe("CreateVM", func() {
 			Expect(registryClient.UpdateCalled).To(BeFalse())
 		})
 
+		It("uses the gcp image url directly if provided", func() {
+			stemcellLink := "https://www.googleapis.com/compute/v1/projects/fake/stemcell/path"
+			_, err = createVM.Run("fake-agent-id", StemcellCID(stemcellLink), cloudProps, networks, disks, env)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(imageService.FindCalled).To(BeFalse())
+			Expect(vmService.CreateVMProps.Stemcell).To(Equal(stemcellLink))
+		})
+
 		It("returns an error if stemcell is not found", func() {
 			imageService.FindFound = false
 

--- a/src/bosh-google-cpi/action/delete_stemcell.go
+++ b/src/bosh-google-cpi/action/delete_stemcell.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"strings"
+
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 
 	"bosh-google-cpi/google/image_service"
@@ -19,6 +21,10 @@ func NewDeleteStemcell(
 }
 
 func (ds DeleteStemcell) Run(stemcellCID StemcellCID) (interface{}, error) {
+	if strings.HasPrefix(string(stemcellCID), "https://www.googleapis.com/compute/v1/projects/") {
+		return nil, nil
+	}
+
 	if err := ds.imageService.Delete(string(stemcellCID)); err != nil {
 		return nil, bosherr.WrapErrorf(err, "Deleting stemcell '%s'", stemcellCID)
 	}

--- a/src/bosh-google-cpi/action/delete_stemcell_test.go
+++ b/src/bosh-google-cpi/action/delete_stemcell_test.go
@@ -40,5 +40,11 @@ var _ = Describe("DeleteStemcell", func() {
 			Expect(err.Error()).To(ContainSubstring("fake-image-service-error"))
 			Expect(imageService.DeleteCalled).To(BeTrue())
 		})
+
+		It("ignores stemcells that are google images", func() {
+			_, err = deleteStemcell.Run("https://www.googleapis.com/compute/v1/projects/a/b/c/d/e/fake-stemcell-id")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(imageService.DeleteCalled).To(BeFalse())
+		})
 	})
 })

--- a/src/bosh-google-cpi/integration/config.go
+++ b/src/bosh-google-cpi/integration/config.go
@@ -46,6 +46,7 @@ var (
 	instanceGroup        = envOrDefault("BACKEND_SERVICE", "cfintegration")
 	zone                 = envOrDefault("ZONE", "us-central1-a")
 	region               = envOrDefault("REGION", "us-central1")
+	imageURL             = envOrDefault("IMAGE_URL", "https://www.googleapis.com/compute/v1/projects/ubuntu-os-cloud/global/images/ubuntu-1404-trusty-v20161213")
 
 	// Channel that will be used to retrieve IPs to use
 	ips chan string

--- a/src/bosh-google-cpi/integration/stemcell_test.go
+++ b/src/bosh-google-cpi/integration/stemcell_test.go
@@ -36,4 +36,31 @@ var _ = Describe("Stemcell", func() {
 		Expect(response.Result).To(BeNil())
 
 	})
+
+	It("executes the stemcell lifecycle with an image_url", func() {
+		var stemcellCID string
+
+		By("uploading a stemcell with image_url")
+		request := fmt.Sprintf(`{
+         "method": "create_stemcell",
+         "arguments": ["", {
+           "name": "bosh-google-kvm-ubuntu-trusty",
+           "version": "3215",
+           "infrastructure": "google",
+           "image_url": "%s"
+         }]
+       }`, imageURL)
+		stemcellCID = assertSucceedsWithResult(request).(string)
+
+		By("deleting the stemcell")
+		request = fmt.Sprintf(`{
+         "method": "delete_stemcell",
+         "arguments": ["%v"]
+       }`, stemcellCID)
+
+		response, err := execCPI(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.Error).To(BeNil())
+		Expect(response.Result).To(BeNil())
+	})
 })


### PR DESCRIPTION
Windows images cannot be imported. For this reason
`StemcellCloudProperties` now has a new property
`ImageURL` which means that instead of creating a
new GCP image from a tarball (either inside the
stem cell or on GCS), the existing gcp image will
be used for new instances.

[#135362799]

Signed-off-by: Charlie Vieth <cviethjr@pivotal.io>
Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>