### PR TITLE
ci: Create an instance for internal load balancing

### DIFF
--- a/ci/tasks/setup-infrastructure.sh
+++ b/ci/tasks/setup-infrastructure.sh
@@ -55,6 +55,8 @@ gcloud -q compute backend-services add-backend ${google_backend_service} --insta
 # Region Backend service
 gcloud -q compute instance-groups unmanaged create ${google_region_backend_service} --zone ${google_zone}
 gcloud -q compute health-checks create tcp ${google_region_backend_service}
+gcloud -q compute instances create ${google_region_backend_service} --zone ${google_zone} --network ${google_network} --machine-type f1-micro
+gcloud -q compute instance-groups unmanaged add-instances ${google_region_backend_service} --instances ${google_region_backend_service} --zone ${google_zone}
 gcloud -q compute backend-services create ${google_region_backend_service} --region ${google_region} --health-checks ${google_region_backend_service} --protocol "TCP" --load-balancing-scheme "INTERNAL" --timeout "30"
 gcloud -q compute backend-services add-backend ${google_region_backend_service} --instance-group ${google_region_backend_service} --zone ${google_zone} --region ${google_region}
 

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -59,6 +59,7 @@ gcloud -q compute http-health-checks delete ${google_backend_service}
 gcloud -q compute instance-groups unmanaged delete ${google_backend_service}
 gcloud -q compute backend-services delete ${google_region_backend_service} --region ${google_region}
 gcloud -q compute health-checks delete ${google_region_backend_service}
+gcloud -q compute instances delete ${google_region_backend_service} --zone ${google_zone}
 gcloud -q compute instance-groups unmanaged delete ${google_region_backend_service} --zone ${google_zone}
 
 set -e


### PR DESCRIPTION
#141 had errors because for internal load balancing, instance groups need a network associated with them, and the only way to currently make that association is by adding an instance to the instance group. This change adds a micro instance to the instance group to fix that error.