### PR TITLE
all: Support VM labels in cloud_properties

### DIFF
--- a/src/bosh-google-cpi/README.md
+++ b/src/bosh-google-cpi/README.md
@@ -133,6 +133,7 @@ These options are specified under `cloud_properties` at the [resource_pools](htt
 | ephemeral_external_ip | N        | Boolean       | Overrides the equivalent option in the networks section
 | ip_forwarding         | N        | Boolean       | Overrides the equivalent option in the networks section
 | tags                  | N        | Array&lt;String&gt; | Merged with tags from the networks section
+| labels                  | N        | Map&lt;String,String&gt; | A dictionary of (key,value) labels applied to the VM
 
 ### BOSH Persistent Disks options
 

--- a/src/bosh-google-cpi/action/cloud_properties.go
+++ b/src/bosh-google-cpi/action/cloud_properties.go
@@ -54,12 +54,17 @@ type VMCloudProperties struct {
 	TargetPool          string           `json:"target_pool,omitempty"`
 	BackendService      interface{}      `json:"backend_service,omitempty"`
 	Tags                instance.Tags    `json:"tags,omitempty"`
+	Labels              instance.Labels  `json:"labels,omitempty"`
 	EphemeralExternalIP *bool            `json:"ephemeral_external_ip,omitempty"`
 	IPForwarding        *bool            `json:"ip_forwarding,omitempty"`
 }
 
 func (n VMCloudProperties) Validate() error {
 	if err := n.Tags.Validate(); err != nil {
+		return err
+	}
+
+	if err := n.Labels.Validate(); err != nil {
 		return err
 	}
 

--- a/src/bosh-google-cpi/action/create_vm.go
+++ b/src/bosh-google-cpi/action/create_vm.go
@@ -108,7 +108,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		}
 	}
 
-	// Validate VM tags
+	// Validate VM tags and labels
 	if err = cloudProps.Validate(); err != nil {
 		return "", bosherr.WrapError(err, "Creating VM")
 	}
@@ -142,6 +142,7 @@ func (cv CreateVM) Run(agentID string, stemcellCID StemcellCID, cloudProps VMClo
 		TargetPool:        cloudProps.TargetPool,
 		BackendService:    bs,
 		Tags:              cloudProps.Tags,
+		Labels:            cloudProps.Labels,
 	}
 
 	// Create VM

--- a/src/bosh-google-cpi/google/instance_service/google_instance_set_metadata.go
+++ b/src/bosh-google-cpi/google/instance_service/google_instance_set_metadata.go
@@ -2,18 +2,11 @@ package instance
 
 import (
 	"fmt"
-	"regexp"
-	"strings"
 
 	"bosh-google-cpi/api"
 	"bosh-google-cpi/util"
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 	computebeta "google.golang.org/api/compute/v0.beta"
-)
-
-var (
-	numFirstRe  = regexp.MustCompile("^[0-9]")
-	mustMatchRe = regexp.MustCompile("^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$")
 )
 
 func (i GoogleInstanceService) SetMetadata(id string, vmMetadata Metadata) error {
@@ -90,33 +83,4 @@ func (i GoogleInstanceService) SetMetadata(id string, vmMetadata Metadata) error
 	}
 
 	return nil
-}
-
-func SafeLabel(s string) (string, error) {
-	maxlen := 61
-	// Replace common invalid chars
-	s = strings.Replace(s, "/", "-", -1)
-	s = strings.Replace(s, "_", "-", -1)
-	s = strings.Replace(s, ":", "-", -1)
-
-	// Trim to max length
-	if len(s) > maxlen {
-		s = s[0:maxlen]
-	}
-
-	// Ensure the string doesn't begin or end in -
-	s = strings.TrimSuffix(s, "-")
-	s = strings.TrimPrefix(s, "-")
-
-	// Ensure the string doesn't begin with a number
-	if numFirstRe.MatchString(s) {
-		s = "n" + s
-	}
-
-	// The sanitized value should pass the GCE regex
-	if mustMatchRe.MatchString(s) {
-		return s, nil
-	}
-
-	return "", fmt.Errorf("Label value %q did not satisfy the GCE label regexp", s)
 }

--- a/src/bosh-google-cpi/google/instance_service/instance_service.go
+++ b/src/bosh-google-cpi/google/instance_service/instance_service.go
@@ -39,6 +39,7 @@ type Properties struct {
 	TargetPool        string
 	BackendService    BackendService
 	Tags              Tags
+	Labels            Labels
 }
 
 type ServiceScopes []string

--- a/src/bosh-google-cpi/google/instance_service/labels.go
+++ b/src/bosh-google-cpi/google/instance_service/labels.go
@@ -1,0 +1,58 @@
+package instance
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+type Labels map[string]string
+
+func (i *Labels) Validate() error {
+	for k, v := range *i {
+		if !mustMatchRe.MatchString(k) {
+			return fmt.Errorf("Label key %q is invalid. Must batch regular expression %q", k, mustMatchReP)
+		}
+		if !mustMatchRe.MatchString(v) {
+			return fmt.Errorf("Label value %q is invalid. Must batch regular expression %q", v, mustMatchReP)
+		}
+	}
+	return nil
+}
+
+var (
+	numFirstRe   = regexp.MustCompile("^[0-9]")
+	mustMatchReP = "^(?:[a-z](?:[-a-z0-9]{0,61}[a-z0-9])?)$"
+	mustMatchRe  = regexp.MustCompile(mustMatchReP)
+)
+
+// This function sanitizes an string, ensuring it is a valid label.
+// It is used to clean up labels provided via BOSH metadata.
+func SafeLabel(s string) (string, error) {
+	maxlen := 61
+	// Replace common invalid chars
+	s = strings.Replace(s, "/", "-", -1)
+	s = strings.Replace(s, "_", "-", -1)
+	s = strings.Replace(s, ":", "-", -1)
+
+	// Trim to max length
+	if len(s) > maxlen {
+		s = s[0:maxlen]
+	}
+
+	// Ensure the string doesn't begin or end in -
+	s = strings.TrimSuffix(s, "-")
+	s = strings.TrimPrefix(s, "-")
+
+	// Ensure the string doesn't begin with a number
+	if numFirstRe.MatchString(s) {
+		s = "n" + s
+	}
+
+	// The sanitized value should pass the GCE regex
+	if mustMatchRe.MatchString(s) {
+		return s, nil
+	}
+
+	return "", fmt.Errorf("Label value %q did not satisfy the GCE label regexp", s)
+}

--- a/src/bosh-google-cpi/integration/vm_test.go
+++ b/src/bosh-google-cpi/integration/vm_test.go
@@ -49,7 +49,11 @@ var _ = Describe("VM", func() {
 				"%v",
 				{
 				  "machine_type": "n1-standard-1",
-				  "zone": "%v"
+				  "zone": "%v",
+				  "labels": {
+					"label-1-key": "label-1-value",
+					"label-2-key": "label-2-value"
+				  }
 				},
 				{
 				  "default": {
@@ -79,7 +83,21 @@ var _ = Describe("VM", func() {
 		exists := assertSucceedsWithResult(request).(bool)
 		Expect(exists).To(Equal(true))
 
-		By("setting the VM's metadata")
+		expectLabels := map[string]string{
+			"integration-delete": "",
+			"micro-google":       "",
+			"dummy":              "",
+			"micro-google-dummy": "",
+			"dummy-dummy":        "",
+			"micro-google-dummy-dummy-too-long-and-should-be-truncated-to": "",
+			"label-1-key": "label-1-value",
+			"label-2-key": "label-2-value",
+		}
+		assertValidVMB(vmCID, func(instance *computebeta.Instance) {
+			// Labels should be an exact match
+			Expect(instance.Labels).To(BeEquivalentTo(expectLabels))
+		})
+
 		m := map[string]string{
 			"director":           "val-that-is-definitely-for-sure-absolutely-longer-than-the-allowable-enforced-63-char-limit-and-should-be-truncated",
 			"name":               "val_with_underscores_ending_in_dash-",
@@ -88,7 +106,7 @@ var _ = Describe("VM", func() {
 			"index":              "0",
 			"integration-delete": "",
 		}
-		expectLabels := map[string]string{
+		expectLabels = map[string]string{
 			"director":           "val-that-is-definitely-for-sure-absolutely-longer-than-the-al",
 			"name":               "val-with-underscores-ending-in-dash",
 			"deployment":         "deployment-name",
@@ -100,6 +118,8 @@ var _ = Describe("VM", func() {
 			"micro-google-dummy": "",
 			"dummy-dummy":        "",
 			"micro-google-dummy-dummy-too-long-and-should-be-truncated-to": "",
+			"label-1-key": "label-1-value",
+			"label-2-key": "label-2-value",
 		}
 		mj, _ := json.Marshal(m)
 		request = fmt.Sprintf(`{


### PR DESCRIPTION
This change introduces support for VM labels (a key=value map) to a
resource pool's cloud_properties section.