### PR TITLE
Support for customizing user agent strings

### DIFF
--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -12,8 +12,11 @@ pushd bosh-cpi-src
   echo "Using BOSH CLI version..."
   bosh version
 
+  echo "Exposing release semver to bosh-google-cpi"
+  echo ${semver} > "src/bosh-google-cpi/release"
+
   echo "Creating CPI BOSH Release..."
-  bosh create release --name ${cpi_release_name} --version ${semver} --with-tarball
+  bosh create release --name ${cpi_release_name} --version ${semver} --with-tarball --force
 popd
 
 image_path=bosh-cpi-src/dev_releases/${cpi_release_name}/${cpi_release_name}-${semver}.tgz

--- a/ci/tasks/build-candidate.sh
+++ b/ci/tasks/build-candidate.sh
@@ -15,6 +15,7 @@ pushd bosh-cpi-src
   echo "Exposing release semver to bosh-google-cpi"
   echo ${semver} > "src/bosh-google-cpi/release"
 
+  # We have to use the --force flag because we just added the `src/bosh-google-cpi/release` file
   echo "Creating CPI BOSH Release..."
   bosh create release --name ${cpi_release_name} --version ${semver} --with-tarball --force
 popd

--- a/jobs/google_cpi/spec
+++ b/jobs/google_cpi/spec
@@ -15,8 +15,8 @@ templates:
 properties:
   google.project:
     description: "Google Compute Engine project"
-  google.user_agent:
-    description: "User Agent"
+  google.user_agent_prefix:
+    description: "User Agent Prefix"
     default: ""
   google.json_key:
     description: "Google Compute Engine JSON key"

--- a/jobs/google_cpi/spec
+++ b/jobs/google_cpi/spec
@@ -15,6 +15,9 @@ templates:
 properties:
   google.project:
     description: "Google Compute Engine project"
+  google.user_agent:
+    description: "User Agent"
+    default: ""
   google.json_key:
     description: "Google Compute Engine JSON key"
     default: ""

--- a/jobs/google_cpi/templates/config/cpi.json.erb
+++ b/jobs/google_cpi/templates/config/cpi.json.erb
@@ -5,6 +5,7 @@ params = {
     "properties" => {
       "google" => {
         "project" => p("google.project"),
+        "user_agent" => p("google.user_agent"),
         "json_key" => p("google.json_key"),
         "default_root_disk_size_gb" => p("google.default_root_disk_size_gb"),
         "default_root_disk_type" => p("google.default_root_disk_type")
@@ -21,6 +22,9 @@ params = {
 
 if_p('google.project') do |project|
   params["cloud"]["properties"]["google"]["project"] = project
+end
+if_p('google.user_agent') do |user_agent|
+  params["cloud"]["properties"]["google"]["user_agent"] = user_agent
 end
 if_p('google.json_key') do |json_key|
   params["cloud"]["properties"]["google"]["json_key"] = json_key

--- a/jobs/google_cpi/templates/config/cpi.json.erb
+++ b/jobs/google_cpi/templates/config/cpi.json.erb
@@ -5,7 +5,7 @@ params = {
     "properties" => {
       "google" => {
         "project" => p("google.project"),
-        "user_agent" => p("google.user_agent"),
+        "user_agent_prefix" => p("google.user_agent_prefix"),
         "json_key" => p("google.json_key"),
         "default_root_disk_size_gb" => p("google.default_root_disk_size_gb"),
         "default_root_disk_type" => p("google.default_root_disk_type")
@@ -23,8 +23,8 @@ params = {
 if_p('google.project') do |project|
   params["cloud"]["properties"]["google"]["project"] = project
 end
-if_p('google.user_agent') do |user_agent|
-  params["cloud"]["properties"]["google"]["user_agent"] = user_agent
+if_p('google.user_agent_prefix') do |user_agent_prefix|
+  params["cloud"]["properties"]["google"]["user_agent_prefix"] = user_agent_prefix
 end
 if_p('google.json_key') do |json_key|
   params["cloud"]["properties"]["google"]["json_key"] = json_key

--- a/src/bosh-google-cpi/Makefile
+++ b/src/bosh-google-cpi/Makefile
@@ -2,11 +2,11 @@ default: test
 
 # Builds bosh-google-cpi for linux-amd64
 build:
-	go build -ldflags="-X bosh-google-cpi/google/config.CpiRelease=`cat release 2>/dev/null`" -o out/cpi bosh-google-cpi/main
+	go build -ldflags="-X bosh-google-cpi/google/config.cpiRelease=`cat release 2>/dev/null`" -o out/cpi bosh-google-cpi/main
 
 # Build cross-platform binaries
 build-all:
-	gox -output="out/cpi_{{.OS}}_{{.Arch}}" -ldflags="-X bosh-google-cpi/google/config.CpiRelease=`cat release 2>/dev/null`" bosh-google-cpi/main
+	gox -output="out/cpi_{{.OS}}_{{.Arch}}" -ldflags="-X bosh-google-cpi/google/config.cpiRelease=`cat release 2>/dev/null`" bosh-google-cpi/main
 
 # Prepration for tests
 get-deps:

--- a/src/bosh-google-cpi/Makefile
+++ b/src/bosh-google-cpi/Makefile
@@ -2,11 +2,11 @@ default: test
 
 # Builds bosh-google-cpi for linux-amd64
 build:
-	go build -o out/cpi bosh-google-cpi/main
+	go build -ldflags="-X bosh-google-cpi/google/config.release=`cat release 2>/dev/null`" -o out/cpi bosh-google-cpi/main
 
 # Build cross-platform binaries
 build-all:
-	gox -output="out/cpi_{{.OS}}_{{.Arch}}" bosh-google-cpi/main
+	gox -output="out/cpi_{{.OS}}_{{.Arch}}" -ldflags="-X bosh-google-cpi/google/config.release=`cat release 2>/dev/null`" bosh-google-cpi/main
 
 # Prepration for tests
 get-deps:

--- a/src/bosh-google-cpi/Makefile
+++ b/src/bosh-google-cpi/Makefile
@@ -2,11 +2,11 @@ default: test
 
 # Builds bosh-google-cpi for linux-amd64
 build:
-	go build -ldflags="-X bosh-google-cpi/google/config.release=`cat release 2>/dev/null`" -o out/cpi bosh-google-cpi/main
+	go build -ldflags="-X bosh-google-cpi/google/config.CpiRelease=`cat release 2>/dev/null`" -o out/cpi bosh-google-cpi/main
 
 # Build cross-platform binaries
 build-all:
-	gox -output="out/cpi_{{.OS}}_{{.Arch}}" -ldflags="-X bosh-google-cpi/google/config.release=`cat release 2>/dev/null`" bosh-google-cpi/main
+	gox -output="out/cpi_{{.OS}}_{{.Arch}}" -ldflags="-X bosh-google-cpi/google/config.CpiRelease=`cat release 2>/dev/null`" bosh-google-cpi/main
 
 # Prepration for tests
 get-deps:

--- a/src/bosh-google-cpi/google/client/google_client.go
+++ b/src/bosh-google-cpi/google/client/google_client.go
@@ -38,7 +38,7 @@ func NewGoogleClient(
 ) (GoogleClient, error) {
 	var err error
 	var computeClient, storageClient *http.Client
-	userAgent := "bosh-google-cpi/0.0.1"
+	userAgent := config.GetUserAgent()
 
 	if config.JSONKey != "" {
 		computeJwtConf, err := oauthgoogle.JWTConfigFromJSON([]byte(config.JSONKey), computeScope)

--- a/src/bosh-google-cpi/google/config/config.go
+++ b/src/bosh-google-cpi/google/config/config.go
@@ -4,7 +4,7 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
-var CpiRelease string
+var cpiRelease string
 
 type Config struct {
 	Project               string `json:"project"`
@@ -15,14 +15,14 @@ type Config struct {
 }
 
 func (c Config) GetUserAgent() string {
-	boshCpiUserAgent := "bosh-google-cpi/" + CpiRelease
-	if CpiRelease == "" {
-		boshCpiUserAgent = boshCpiUserAgent + "dev"
+	if cpiRelease == "" {
+		cpiRelease = "dev"
 	}
+	userAgent := "bosh-google-cpi/" + cpiRelease
 	if c.UserAgentPrefix == "" {
-		return boshCpiUserAgent
+		return userAgent
 	}
-	return c.UserAgentPrefix + " " + boshCpiUserAgent
+	return c.UserAgentPrefix + " " + userAgent
 }
 
 func (c Config) Validate() error {

--- a/src/bosh-google-cpi/google/config/config.go
+++ b/src/bosh-google-cpi/google/config/config.go
@@ -4,7 +4,7 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
-var release string
+var CpiRelease string
 
 type Config struct {
 	Project               string `json:"project"`
@@ -15,8 +15,8 @@ type Config struct {
 }
 
 func (c Config) GetUserAgent() string {
-	boshCpiUserAgent := "bosh-google-cpi/" + release
-	if release == "" {
+	boshCpiUserAgent := "bosh-google-cpi/" + CpiRelease
+	if CpiRelease == "" {
 		boshCpiUserAgent = boshCpiUserAgent + "dev"
 	}
 	if c.UserAgentPrefix == "" {

--- a/src/bosh-google-cpi/google/config/config.go
+++ b/src/bosh-google-cpi/google/config/config.go
@@ -4,6 +4,8 @@ import (
 	bosherr "github.com/cloudfoundry/bosh-utils/errors"
 )
 
+var release string
+
 type Config struct {
 	Project               string `json:"project"`
 	UserAgent             string `json:"user_agent"`
@@ -13,7 +15,10 @@ type Config struct {
 }
 
 func (c Config) GetUserAgent() string {
-	boshCpiUserAgent := "bosh-google-cpi/0.0.1"
+	boshCpiUserAgent := "bosh-google-cpi/" + release
+	if release == "" {
+		boshCpiUserAgent = boshCpiUserAgent + "dev"
+	}
 	if c.UserAgent == "" {
 		return boshCpiUserAgent
 	}

--- a/src/bosh-google-cpi/google/config/config.go
+++ b/src/bosh-google-cpi/google/config/config.go
@@ -8,7 +8,7 @@ var release string
 
 type Config struct {
 	Project               string `json:"project"`
-	UserAgent             string `json:"user_agent"`
+	UserAgentPrefix       string `json:"user_agent_prefix"`
 	JSONKey               string `json:"json_key"`
 	DefaultRootDiskSizeGb int    `json:"default_root_disk_size_gb"`
 	DefaultRootDiskType   string `json:"default_root_disk_type"`
@@ -19,10 +19,10 @@ func (c Config) GetUserAgent() string {
 	if release == "" {
 		boshCpiUserAgent = boshCpiUserAgent + "dev"
 	}
-	if c.UserAgent == "" {
+	if c.UserAgentPrefix == "" {
 		return boshCpiUserAgent
 	}
-	return c.UserAgent + " " + boshCpiUserAgent
+	return c.UserAgentPrefix + " " + boshCpiUserAgent
 }
 
 func (c Config) Validate() error {

--- a/src/bosh-google-cpi/google/config/config.go
+++ b/src/bosh-google-cpi/google/config/config.go
@@ -6,9 +6,18 @@ import (
 
 type Config struct {
 	Project               string `json:"project"`
+	UserAgent             string `json:"user_agent"`
 	JSONKey               string `json:"json_key"`
 	DefaultRootDiskSizeGb int    `json:"default_root_disk_size_gb"`
 	DefaultRootDiskType   string `json:"default_root_disk_type"`
+}
+
+func (c Config) GetUserAgent() string {
+	boshCpiUserAgent := "bosh-google-cpi/0.0.1"
+	if c.UserAgent == "" {
+		return boshCpiUserAgent
+	}
+	return c.UserAgent + " " + boshCpiUserAgent
 }
 
 func (c Config) Validate() error {

--- a/src/bosh-google-cpi/google/config/config_internal_test.go
+++ b/src/bosh-google-cpi/google/config/config_internal_test.go
@@ -1,0 +1,44 @@
+package config
+
+
+import (
+        . "github.com/onsi/ginkgo"
+        . "github.com/onsi/gomega"
+)
+
+var _ = Describe("Config", func() {
+        var (
+                config Config
+        )
+
+	Describe("UserAgent", func() {
+                It("returns correct user agent string with release, without prefix", func() {
+                        config.UserAgentPrefix = ""
+                        cpiRelease = "0.0.1"
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("bosh-google-cpi/0.0.1"))
+                })
+                It("returns correct user agent string with release, with prefix", func() {
+                        config.UserAgentPrefix = "Kubo/0.0.2"
+                        cpiRelease = "0.0.1"
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/0.0.1"))
+                })
+                It("returns correct user agent string without release, with prefix", func() {
+                        config.UserAgentPrefix = "Kubo/0.0.2"
+                        cpiRelease = ""
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/dev"))
+                })
+                It("returns correct user agent string without release, without prefix", func() {
+                        config.UserAgentPrefix = ""
+                        cpiRelease = ""
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("bosh-google-cpi/dev"))
+                })
+        })
+})

--- a/src/bosh-google-cpi/google/config/config_test.go
+++ b/src/bosh-google-cpi/google/config/config_test.go
@@ -34,34 +34,4 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Project"))
 		})
 	})
-	Describe("UserAgent", func() {
-		It("returns correct user agent string with release, without prefix", func() {
-			config.UserAgentPrefix = ""
-			CpiRelease = "0.0.1"
-			
-			userAgent := config.GetUserAgent()
-                        Expect(userAgent).To(Equal("bosh-google-cpi/0.0.1"))
-		})
-		It("returns correct user agent string with release, with prefix", func() {
-			config.UserAgentPrefix = "Kubo/0.0.2"
-			CpiRelease = "0.0.1"
-
-			userAgent := config.GetUserAgent()
-			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/0.0.1"))
-		})
-		It("returns correct user agent string without release, with prefix", func() {
-                        config.UserAgentPrefix = "Kubo/0.0.2"
-                        CpiRelease = ""
-
-                        userAgent := config.GetUserAgent()
-                        Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/dev"))
-                })
-		It("returns correct user agent string without release, without prefix", func() {
-                        config.UserAgentPrefix = ""
-                        CpiRelease = ""
-
-                        userAgent := config.GetUserAgent()
-                        Expect(userAgent).To(Equal("bosh-google-cpi/dev"))
-                })
-	})
 })

--- a/src/bosh-google-cpi/google/config/config_test.go
+++ b/src/bosh-google-cpi/google/config/config_test.go
@@ -36,16 +36,16 @@ var _ = Describe("Config", func() {
 	})
 	Describe("UserAgent", func() {
 		It("returns a valid user agent string without external user agent", func() {
-			config.UserAgent = ""
+			config.UserAgentPrefix = ""
 			
 			userAgent := config.GetUserAgent()
-                        Expect(userAgent).To(Equal("bosh-google-cpi/0.0.1"))
+                        Expect(userAgent).To(Equal("bosh-google-cpi/dev"))
 		})
 		It("returns a valid user agent string with external user agent", func() {
-			config.UserAgent = "Kubo/0.0.2"
+			config.UserAgentPrefix = "Kubo/0.0.2"
 
 			userAgent := config.GetUserAgent()
-			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/0.0.1"))
+			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/dev"))
 		})
 	})
 })

--- a/src/bosh-google-cpi/google/config/config_test.go
+++ b/src/bosh-google-cpi/google/config/config_test.go
@@ -34,4 +34,18 @@ var _ = Describe("Config", func() {
 			Expect(err.Error()).To(ContainSubstring("Must provide a non-empty Project"))
 		})
 	})
+	Describe("UserAgent", func() {
+		It("returns a valid user agent string without external user agent", func() {
+			config.UserAgent = ""
+			
+			userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("bosh-google-cpi/0.0.1"))
+		})
+		It("returns a valid user agent string with external user agent", func() {
+			config.UserAgent = "Kubo/0.0.2"
+
+			userAgent := config.GetUserAgent()
+			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/0.0.1"))
+		})
+	})
 })

--- a/src/bosh-google-cpi/google/config/config_test.go
+++ b/src/bosh-google-cpi/google/config/config_test.go
@@ -35,17 +35,33 @@ var _ = Describe("Config", func() {
 		})
 	})
 	Describe("UserAgent", func() {
-		It("returns a valid user agent string without external user agent", func() {
+		It("returns correct user agent string with release, without prefix", func() {
 			config.UserAgentPrefix = ""
+			CpiRelease = "0.0.1"
 			
 			userAgent := config.GetUserAgent()
-                        Expect(userAgent).To(Equal("bosh-google-cpi/dev"))
+                        Expect(userAgent).To(Equal("bosh-google-cpi/0.0.1"))
 		})
-		It("returns a valid user agent string with external user agent", func() {
+		It("returns correct user agent string with release, with prefix", func() {
 			config.UserAgentPrefix = "Kubo/0.0.2"
+			CpiRelease = "0.0.1"
 
 			userAgent := config.GetUserAgent()
-			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/dev"))
+			Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/0.0.1"))
 		})
+		It("returns correct user agent string without release, with prefix", func() {
+                        config.UserAgentPrefix = "Kubo/0.0.2"
+                        CpiRelease = ""
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("Kubo/0.0.2 bosh-google-cpi/dev"))
+                })
+		It("returns correct user agent string without release, without prefix", func() {
+                        config.UserAgentPrefix = ""
+                        CpiRelease = ""
+
+                        userAgent := config.GetUserAgent()
+                        Expect(userAgent).To(Equal("bosh-google-cpi/dev"))
+                })
 	})
 })


### PR DESCRIPTION
This PR makes 2 changes to the user agent string:

1. Allows clients of the CPI to pass in a new cloud property called user_agent_prefix which will be prepended to the user agent string

2. The user agent string will now include the version of the CPI that is being run