### PR TITLE
ci, docs: ssh removed in new stemcells

### DIFF
--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -215,12 +215,6 @@ cloud_provider:
     name: google_cpi
     release: bosh-google-cpi
 
-  ssh_tunnel:
-    host: ${director_ip}
-    port: 22
-    user: ${private_key_user}
-    private_key: ${private_key}
-
   mbus: https://mbus:mbus-password@${director_ip}:6868
 
   properties:

--- a/docs/bosh/README.md
+++ b/docs/bosh/README.md
@@ -246,8 +246,8 @@ Now you have the infrastructure ready to deploy a BOSH director.
      - name: vms
        network: private
        stemcell:
-         url: https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3312.15
-         sha1: 3ac3ee83750f75bd74e8d3e3ad97808db23c30ba
+         url: https://s3.amazonaws.com/bosh-gce-light-stemcells/light-bosh-stemcell-3421.9-google-kvm-ubuntu-trusty-go_agent.tgz
+         sha1: 408f78a2091d108bb5418964026e73c822def32d
        cloud_properties:
          zone: <%= ENV['zone'] %>
          machine_type: n1-standard-1
@@ -378,12 +378,6 @@ Now you have the infrastructure ready to deploy a BOSH director.
      template:
        name: google_cpi
        release: bosh-google-cpi
-
-     ssh_tunnel:
-       host: <%= ENV['base_ip'].split('.').tap{|i| i[-1] = i[-1].to_i + 6 }.join('.') %>
-       port: 22
-       user: bosh
-       private_key: <%= ENV['ssh_key_path'] %>
 
      mbus: https://mbus:mbus-password@<%= ENV['base_ip'].split('.').tap{|i| i[-1] = i[-1].to_i + 6 }.join('.') %>:6868
 


### PR DESCRIPTION
The 3421+ stemcells can no longer be used as hosts for ssh_tunnel
because you can no longer SSH directly into the director but need
to use `bosh ssh`.

On GCP we recommend using a jumpbox (bosh-bastion) that has
access to the VPC with bosh resources and not exposing any of these
resources with external IPs. This jumpbox can be secured for the
environment and used as a ssh_tunnel into the cluster if desired.

Change:
- Update the docs to not use ssh_tunnel and remove the feature use in CI.

Validation:
- Deployed bosh director with updated manifest

Note: 
Updating the stemcell URL to `https://bosh.io/d/stemcells/bosh-google-kvm-ubuntu-trusty-go_agent?v=3421.9` gave me an error about the incorrect sha1 so I went with the URL that bosh.io redirects to. 

Related #199