### PR TITLE
Include sane pipeline credential defaults

### DIFF
--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -22,30 +22,49 @@ google_json_key_data: |
 # The following configuration values are names of resources that will be
 # automatically created and destroyed in the pipeline. They must not conflict
 # with existing resources in {{google_project}}
-google_service_account: # Name of a service account that will be used in integration tests
-google_auto_network: # Name of an auto-configured network in {{google_project}
-google_network: # Name of a manually-configured network in {{google_project}
-google_subnetwork: # Name of a manually-configured subnetwork in {{google_network}}
-google_firewall_internal: # Name of firewall for internal access
-google_firewall_external: # Name of firewall for internal access
-google_address_int_ubuntu: # Name of an external IP address used in integration tests
-google_address_bats_ubuntu: # Name of an external IP address used in BATS tests
-google_address_director_ubuntu: # Name of an external IP address used to create a director
-google_target_pool: # Name of a network target pool
-google_backend_service: # Name of a backend service
-google_region_backend_service: # Name of a region backend service
+# Name of a service account that will be used in integration tests
+google_service_account: google-cpi-ci-service-account
+# Name of an auto-configured network in {{google_project}}
+google_auto_network: google-cpi-ci-auto-network
+# Name of a manually-configured network in {{google_project}}
+google_network: google-cpi-ci-network
+# Name of a manually-configured subnetwork in {{google_network}}
+google_subnetwork: google-cpi-ci-subnetwork
+# Name of firewall for internal access
+google_firewall_internal: google-cpi-ci-firewall-internal
+# Name of firewall for external access
+google_firewall_external: google-cpi-ci-firewall-external
+# Name of an external IP address used in integration tests
+google_address_int_ubuntu: google-cpi-ci-ip-int-ubuntu
+# Name of an external IP address used in BATS tests
+google_address_bats_ubuntu: google-cpi-ci-ip-bats-ubuntu
+# Name of an external IP address used to create a director
+google_address_director_ubuntu: google-cpi-ci-ip-director-ubuntu
+# Name of a network target pool
+google_target_pool: google-cpi-ci-target-pool
+# Name of a backend service
+google_backend_service: google-cpi-ci-backend-service
+# Name of a region backend service
+google_region_backend_service: google-cpi-ci-regional-backend-service
 
 # Networking configuration
-google_subnetwork_range: # The CIDR range of {{google_subnetwork}}
-google_subnetwork_gw: # The gateway IP of {{google_subnetwork}}
+# The CIDR range of {{google_subnetwork}}
+google_subnetwork_range: 10.0.0.0/24
+# The gateway IP of {{google_subnetwork}}
+google_subnetwork_gw: 10.0.0.1
 
 # All of the following IP addresses must be within {{google_subnetwork}}'s CIDR
 # and be unique.
-google_address_static_int_ubuntu: # Three comma-delimited IP address in {{google_subnetwork}}
-google_address_static_director_ubuntu: # A private IP address in {{google_subnetwork}}
-google_address_static_bats_ubuntu: # A private IP address in {{google_subnetwork}}
-google_address_static_pair_bats_ubuntu: # Two comma-delimited IP address in {{google_subnetwork}}
-google_address_static_bats_available_range_ubuntu: # Hyphen-delimited range that contains {{google_address_static_pair_bats_ubuntu}} and {{google_address_static_bats_ubuntu}}
+# Three comma-delimited IP address in {{google_subnetwork}}
+google_address_static_int_ubuntu: 10.0.0.100,10.0.0.101,10.0.0.102
+# A private IP address in {{google_subnetwork}}
+google_address_static_director_ubuntu: 10.0.0.6
+# A private IP address in {{google_subnetwork}}
+google_address_static_bats_ubuntu: 10.0.0.20
+# Two comma-delimited IP address in {{google_subnetwork}}
+google_address_static_pair_bats_ubuntu: 10.0.0.20,10.0.0.21
+# Hyphen-delimited range that contains {{google_address_static_pair_bats_ubuntu}} and {{google_address_static_bats_ubuntu}}
+google_address_static_bats_available_range_ubuntu: 10.0.0.20-10.0.0.30
 
 # SSH and auth information
 private_key_user: vcap


### PR DESCRIPTION
Currently, setting up the CI pipeline is difficult due to the
number of fields that must be configured in `credentials.yml.tpl`.
Many of those fields can be safely set to default values as they
reference GCP project-internal temporary resources.

This change introduces default values to the created resources and
networking configuration. These are known to work together and
should reduce the friction to creating the pipeline from scratch.
This reduces the number of fields to fill from 40 to 16.