### PR TITLE
Make gce-light-stemcell pipeline more resilient

### DIFF
--- a/ci/stemcell/light/configure.sh
+++ b/ci/stemcell/light/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 fly -t cpi set-pipeline -p light-gce-stemcells \
-  -c ./ci/stemcell/light/pipeline.yml \
+  -c pipeline.yml \
   -l <(lpass show --note "google stemcell concourse secrets")

--- a/ci/stemcell/light/configure.sh
+++ b/ci/stemcell/light/configure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-fly -t cpi set-pipeline -p light-gce-stemcells \
+fly -t cpi sp -p light-gce-stemcells \
   -c pipeline.yml \
   -l <(lpass show --note "google stemcell concourse secrets")

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -63,31 +63,31 @@ shared:
     aggregate:
     - put: bosh-ubuntu-raw-stemcells
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw-*.tar.gz
         predefined_acl: "publicRead"
     - put: bosh-ubuntu-raw-stemcells-sha1
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw-*.tar.gz.sha1
         predefined_acl: "publicRead"
   - &upload-ubuntu-raw-alpha-stemcells
     aggregate:
     - put: bosh-ubuntu-raw-alpha-stemcells
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw-*.tar.gz
         predefined_acl: "publicRead"
     - put: bosh-ubuntu-raw-alpha-stemcells-sha1
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw.tar.gz.sha1
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-ubuntu-trusty-go_agent-raw-*.tar.gz.sha1
         predefined_acl: "publicRead"
   - &upload-centos-raw-stemcells
     aggregate:
     - put: bosh-centos-raw-stemcells
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw.tar.gz
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw-*.tar.gz
         predefined_acl: "publicRead"
     - put: bosh-centos-raw-stemcells-sha1
       params:
-        file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw.tar.gz.sha1
+        file: raw-stemcell/bosh-stemcell-*-google-kvm-centos-7-go_agent-raw-*.tar.gz.sha1
         predefined_acl: "publicRead"
   - &verify-alpha-stemcell-boots
     do:

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -6,9 +6,11 @@ groups:
   - ubuntu-trusty-stemcell-3312
   - ubuntu-trusty-stemcell-3363
   - ubuntu-trusty-stemcell-3421
+  - ubuntu-trusty-stemcell-3431
   - centos-7-stemcell-3312
   - centos-7-stemcell-3363
   - centos-7-stemcell-3421
+  - centos-7-stemcell-3431
 - name: alpha
   jobs:
   - ubuntu-trusty-stemcell-alpha
@@ -221,6 +223,24 @@ jobs:
       - *upload-ubuntu-raw-stemcells
       - *verify-stemcell-boots
 
+  - name: ubuntu-trusty-stemcell-3431
+    disable_manual_trigger: true
+    serial: true
+    plan:
+      - aggregate:
+        - get: stemcell
+          resource: ubuntu-stemcell-3431
+          trigger: true
+          version: every
+          params:
+            preserve_filename: true
+        - *get-cpi-src
+        - *get-bosh-cli
+        - *get-cpi-release
+      - *create-light-stemcell
+      - *upload-ubuntu-raw-stemcells
+      - *verify-stemcell-boots
+
   - name: ubuntu-trusty-stemcell-alpha
     serial: true
     plan:
@@ -280,6 +300,24 @@ jobs:
       - aggregate:
         - get: stemcell
           resource: centos-stemcell-3421
+          trigger: true
+          version: every
+          params:
+            preserve_filename: true
+        - *get-cpi-src
+        - *get-bosh-cli
+        - *get-cpi-release
+      - *create-light-stemcell
+      - *upload-centos-raw-stemcells
+      - *verify-stemcell-boots
+
+  - name: centos-7-stemcell-3431
+    disable_manual_trigger: true
+    serial: true
+    plan:
+      - aggregate:
+        - get: stemcell
+          resource: centos-stemcell-3431
           trigger: true
           version: every
           params:
@@ -363,6 +401,13 @@ resources:
       force_regular: true
       version_family: "3421"
 
+  - name: ubuntu-stemcell-3431
+    type: bosh-io-stemcell
+    source:
+      name: bosh-google-kvm-ubuntu-trusty-go_agent
+      force_regular: true
+      version_family: "3431"
+
   - name: ubuntu-stemcell-alpha
     type: s3
     source:
@@ -410,6 +455,13 @@ resources:
       name: bosh-google-kvm-centos-7-go_agent
       force_regular: true
       version_family: "3421"
+
+  - name: centos-stemcell-3431
+    type: bosh-io-stemcell
+    source:
+      name: bosh-google-kvm-centos-7-go_agent
+      force_regular: true
+      version_family: "3431"
 
   - name: bosh-ubuntu-raw-stemcells
     type: gcs-resource

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -1,8 +1,7 @@
 ---
 groups:
-- name: all
+- name: all-gcp
   jobs:
-  - ubuntu-trusty-stemcell-3263
   - ubuntu-trusty-stemcell-3312
   - ubuntu-trusty-stemcell-3363
   - ubuntu-trusty-stemcell-3421
@@ -14,10 +13,6 @@ groups:
   jobs:
   - centos-7-stemcell-3312
   - ubuntu-trusty-stemcell-3312
-
-- name: "3263"
-  jobs:
-  - ubuntu-trusty-stemcell-3263
 
 - name: "3363"
   jobs:
@@ -39,6 +34,7 @@ groups:
   - centos-7-stemcell-3312
   - centos-7-stemcell-3363
   - centos-7-stemcell-3431
+  - ubuntu-trusty-stemcell-3263
   - ubuntu-trusty-stemcell-3431
 
 - name: alpha

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -1,18 +1,46 @@
 ---
 groups:
-- name: light-gce-stemcells
+- name: all
   jobs:
   - ubuntu-trusty-stemcell-3263
   - ubuntu-trusty-stemcell-3312
   - ubuntu-trusty-stemcell-3363
   - ubuntu-trusty-stemcell-3421
-  - ubuntu-trusty-stemcell-3431
   - ubuntu-trusty-stemcell-3445
+  - centos-7-stemcell-3421
+  - centos-7-stemcell-3445
+
+- name: "3312"
+  jobs:
+  - centos-7-stemcell-3312
+  - ubuntu-trusty-stemcell-3312
+
+- name: "3263"
+  jobs:
+  - ubuntu-trusty-stemcell-3263
+
+- name: "3363"
+  jobs:
+  - centos-7-stemcell-3363
+  - ubuntu-trusty-stemcell-3363
+
+- name: "3421"
+  jobs:
+  - centos-7-stemcell-3421
+  - ubuntu-trusty-stemcell-3421
+
+- name: "3445"
+  jobs:
+  - centos-7-stemcell-3445
+  - ubuntu-trusty-stemcell-3445
+
+- name: deprecated
+  jobs:
   - centos-7-stemcell-3312
   - centos-7-stemcell-3363
-  - centos-7-stemcell-3421
   - centos-7-stemcell-3431
-  - centos-7-stemcell-3445
+  - ubuntu-trusty-stemcell-3431
+
 - name: alpha
   jobs:
   - ubuntu-trusty-stemcell-alpha

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -7,10 +7,12 @@ groups:
   - ubuntu-trusty-stemcell-3363
   - ubuntu-trusty-stemcell-3421
   - ubuntu-trusty-stemcell-3431
+  - ubuntu-trusty-stemcell-3445
   - centos-7-stemcell-3312
   - centos-7-stemcell-3363
   - centos-7-stemcell-3421
   - centos-7-stemcell-3431
+  - centos-7-stemcell-3445
 - name: alpha
   jobs:
   - ubuntu-trusty-stemcell-alpha
@@ -243,6 +245,24 @@ jobs:
       - *upload-ubuntu-raw-stemcells
       - *verify-stemcell-boots
 
+  - name: ubuntu-trusty-stemcell-3445
+    disable_manual_trigger: true
+    serial: true
+    plan:
+      - aggregate:
+        - get: stemcell
+          resource: ubuntu-stemcell-3445
+          trigger: true
+          version: every
+          params:
+            preserve_filename: true
+        - *get-cpi-src
+        - *get-bosh-cli
+        - *get-cpi-release
+      - *create-light-stemcell
+      - *upload-ubuntu-raw-stemcells
+      - *verify-stemcell-boots
+
   - name: ubuntu-trusty-stemcell-alpha
     serial: true
     plan:
@@ -320,6 +340,24 @@ jobs:
       - aggregate:
         - get: stemcell
           resource: centos-stemcell-3431
+          trigger: true
+          version: every
+          params:
+            preserve_filename: true
+        - *get-cpi-src
+        - *get-bosh-cli
+        - *get-cpi-release
+      - *create-light-stemcell
+      - *upload-centos-raw-stemcells
+      - *verify-stemcell-boots
+
+  - name: centos-7-stemcell-3445
+    disable_manual_trigger: true
+    serial: true
+    plan:
+      - aggregate:
+        - get: stemcell
+          resource: centos-stemcell-3445
           trigger: true
           version: every
           params:
@@ -410,6 +448,13 @@ resources:
       force_regular: true
       version_family: "3431"
 
+  - name: ubuntu-stemcell-3445
+    type: bosh-io-stemcell
+    source:
+      name: bosh-google-kvm-ubuntu-trusty-go_agent
+      force_regular: true
+      version_family: "3445"
+
   - name: ubuntu-stemcell-alpha
     type: s3
     source:
@@ -464,6 +509,13 @@ resources:
       name: bosh-google-kvm-centos-7-go_agent
       force_regular: true
       version_family: "3431"
+
+  - name: centos-stemcell-3445
+    type: bosh-io-stemcell
+    source:
+      name: bosh-google-kvm-centos-7-go_agent
+      force_regular: true
+      version_family: "3445"
 
   - name: bosh-ubuntu-raw-stemcells
     type: gcs-resource

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -11,12 +11,10 @@ groups:
 
 - name: "3312"
   jobs:
-  - centos-7-stemcell-3312
   - ubuntu-trusty-stemcell-3312
 
 - name: "3363"
   jobs:
-  - centos-7-stemcell-3363
   - ubuntu-trusty-stemcell-3363
 
 - name: "3421"

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -184,7 +184,6 @@ shared:
 
 jobs:
   - name: ubuntu-trusty-stemcell-3312
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -202,7 +201,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: ubuntu-trusty-stemcell-3263
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -220,7 +218,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: ubuntu-trusty-stemcell-3363
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -238,7 +235,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: ubuntu-trusty-stemcell-3421
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -256,7 +252,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: ubuntu-trusty-stemcell-3431
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -274,7 +269,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: ubuntu-trusty-stemcell-3445
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -308,7 +302,6 @@ jobs:
       - *verify-alpha-stemcell-boots
 
   - name: centos-7-stemcell-3312
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -326,7 +319,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: centos-7-stemcell-3363
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -344,7 +336,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: centos-7-stemcell-3421
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -362,7 +353,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: centos-7-stemcell-3431
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:
@@ -380,7 +370,6 @@ jobs:
       - *verify-stemcell-boots
 
   - name: centos-7-stemcell-3445
-    disable_manual_trigger: true
     serial: true
     plan:
       - aggregate:

--- a/ci/stemcell/light/pipeline.yml
+++ b/ci/stemcell/light/pipeline.yml
@@ -29,12 +29,14 @@ shared:
     task: create-light-stemcell
     file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
     params:
-      BUCKET_NAME:     {{google_raw_stemcells_bucket_name}}
+      BUCKET_NAME:         {{google_raw_stemcells_bucket_name}}
+      BOSH_IO_BUCKET_NAME: {{bosh_io_light_stemcell_bucket}}
   - &create-light-alpha-stemcell
     task: create-light-stemcell
     file: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.yml
     params:
-      BUCKET_NAME:     {{google_raw_alpha_stemcells_bucket_name}}
+      BUCKET_NAME:         {{google_raw_alpha_stemcells_bucket_name}}
+      BOSH_IO_BUCKET_NAME: {{bosh_io_light_stemcell_bucket}}
   - &cleanup-failed-run-instructions
     task: cleanup-failed-run-instructions
     config:
@@ -345,7 +347,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release.git
-      branch: develop
+      branch: pivotal-bosh-cpi
 
   - name: alpha-terraform
     type: terraform

--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -23,12 +23,14 @@ light_stemcell_name="light-${original_stemcell_name}"
 echo "Using raw stemcell name: $raw_stemcell_name"
 
 bosh_io_light_stemcell_url="https://s3.amazonaws.com/$BOSH_IO_BUCKET_NAME/$light_stemcell_name"
+set +e
 wget --spider "$bosh_io_light_stemcell_url"
-if [[ "$?" != 0 ]]; then
+if [[ "$?" == "0" ]]; then
   echo "Google light stemcell '$light_stemcell_name' already exists!"
   echo "You can download here: $bosh_io_light_stemcell_url"
   exit 1
 fi
+set -e
 
 mkdir working_dir
 pushd working_dir

--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -14,11 +14,13 @@ raw_stemcell_dir="$PWD/raw-stemcell"
 
 echo "Creating light stemcell..."
 
+salt=$(date +%s)
 original_stemcell="$(echo ${stemcell_dir}/*.tgz)"
 original_stemcell_name="$(basename "${original_stemcell}")"
-raw_stemcell_name="$(basename "${original_stemcell}" .tgz)-raw.tar.gz"
+raw_stemcell_name="$(basename "${original_stemcell}" .tgz)-raw-$salt.tar.gz"
 light_stemcell_name="light-${original_stemcell_name}"
 
+echo "Using raw stemcell name: $raw_stemcell_name"
 
 bosh_io_light_stemcell_url="https://s3.amazonaws.com/$BOSH_IO_BUCKET_NAME/$light_stemcell_name"
 wget --spider "$bosh_io_light_stemcell_url"

--- a/ci/stemcell/light/tasks/build-light-stemcell.sh
+++ b/ci/stemcell/light/tasks/build-light-stemcell.sh
@@ -3,6 +3,7 @@
 set -eu
 
 : ${BUCKET_NAME:?}
+: ${BOSH_IO_BUCKET_NAME:?} # used to check if current stemcell already exists
 
 # inputs
 stemcell_dir="$PWD/stemcell"
@@ -17,6 +18,15 @@ original_stemcell="$(echo ${stemcell_dir}/*.tgz)"
 original_stemcell_name="$(basename "${original_stemcell}")"
 raw_stemcell_name="$(basename "${original_stemcell}" .tgz)-raw.tar.gz"
 light_stemcell_name="light-${original_stemcell_name}"
+
+
+bosh_io_light_stemcell_url="https://s3.amazonaws.com/$BOSH_IO_BUCKET_NAME/$light_stemcell_name"
+wget --spider "$bosh_io_light_stemcell_url"
+if [[ "$?" != 0 ]]; then
+  echo "Google light stemcell '$light_stemcell_name' already exists!"
+  echo "You can download here: $bosh_io_light_stemcell_url"
+  exit 1
+fi
 
 mkdir working_dir
 pushd working_dir

--- a/ci/stemcell/light/tasks/build-light-stemcell.yml
+++ b/ci/stemcell/light/tasks/build-light-stemcell.yml
@@ -18,4 +18,5 @@ run:
   path: bosh-cpi-src/ci/stemcell/light/tasks/build-light-stemcell.sh
 
 params:
-  BUCKET_NAME:  ""
+  BUCKET_NAME:         ""
+  BOSH_IO_BUCKET_NAME: ""


### PR DESCRIPTION
It makes sure that current light stemcell does NOT already exists on bosh.io