### PR TITLE
Fixing terraform call by adding init call and updating disk param

### DIFF
--- a/docs/bosh/README.md
+++ b/docs/bosh/README.md
@@ -116,6 +116,15 @@ The following instructions offer the fastest path to getting BOSH up and running
    cd bosh-google-cpi-release/docs/bosh
    ```
 
+1. Initialize the Terraform cloud provider
+```
+   docker run -i -t \
+     -e "GOOGLE_CREDENTIALS=${GOOGLE_CREDENTIALS}" \
+     -v `pwd`:/$(basename `pwd`) \
+     -w /$(basename `pwd`) \
+     hashicorp/terraform:light init
+```
+
 1. View the Terraform execution plan to see the resources that will be created:
 
    ```

--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -115,8 +115,10 @@ resource "google_compute_instance" "bosh-bastion" {
 
   tags = ["bosh-bastion", "internal"]
 
-  disk {
-    image = "${var.latest_ubuntu}"
+  boot_disk {
+    initialize_params {
+      image = "${var.latest_ubuntu}"
+    }
   }
 
   network_interface {
@@ -211,8 +213,10 @@ resource "google_compute_instance" "nat-instance-private-with-nat-primary" {
 
   tags = ["nat", "internal"]
 
-  disk {
-    image = "${var.latest_ubuntu}"
+  boot_disk {
+    initialize_params {
+      image = "${var.latest_ubuntu}"
+    }
   }
 
   network_interface {


### PR DESCRIPTION
Terraform deprecated disk, so I changed it to boot_disk

I wasn't able to run Terraform without running init first