### PR TITLE
action/create_vm: default backend_service scheme

### DIFF
--- a/src/bosh-google-cpi/action/create_vm_test.go
+++ b/src/bosh-google-cpi/action/create_vm_test.go
@@ -171,6 +171,38 @@ var _ = Describe("CreateVM", func() {
 			}
 		})
 
+		Context("when BackendService is set as a hash", func() {
+			var backendService map[string]string
+			BeforeEach(func() {
+				backendService = make(map[string]string)
+				backendService["name"] = "foobar"
+				expectedVMProps.BackendService = instance.BackendService{Name: "foobar", Scheme: "EXTERNAL"}
+
+				cloudProps.BackendService = backendService
+			})
+
+			It("defaults to external", func() {
+				vmCID, err = createVM.Run("fake-agent-id", "fake-stemcell-id", cloudProps, networks, disks, env)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmService.CreateVMProps).To(Equal(expectedVMProps))
+			})
+
+			It("supports internal", func() {
+				backendService["scheme"] = "INTERNAL"
+				expectedVMProps.BackendService = instance.BackendService{Name: "foobar", Scheme: "INTERNAL"}
+
+				vmCID, err = createVM.Run("fake-agent-id", "fake-stemcell-id", cloudProps, networks, disks, env)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(vmService.CreateVMProps).To(Equal(expectedVMProps))
+			})
+
+			It("requires name", func() {
+				delete(backendService, "name")
+				vmCID, err = createVM.Run("fake-agent-id", "fake-stemcell-id", cloudProps, networks, disks, env)
+				Expect(err).To(HaveOccurred())
+			})
+		})
+
 		It("creates the vm", func() {
 			vmCID, err = createVM.Run("fake-agent-id", "fake-stemcell-id", cloudProps, networks, disks, env)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
If the manifest specifies a backend_service as a map we attempt to cast
the name/scheme directly from the map to strings. This results in a
panic instead of a graceful error.

- Rework parsing to check for existance of the value in the
  map[string]interface{} before casting the value
- Default to EXTERNAL load balancing scheme when backend_service is
  specified as a map

Related #231