### PR TITLE
docs/bosh: set network to manual

### DIFF
--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -43,8 +43,9 @@ provider "google" {
 }
 
 resource "google_compute_network" "bosh" {
-  name       = "${var.prefix}bosh"
-  project    = "${var.network_project_id}"
+  name                    = "${var.prefix}bosh"
+  project                 = "${var.network_project_id}"
+  auto_create_subnetworks = "false"
 }
 
 resource "google_compute_route" "nat-primary" {


### PR DESCRIPTION
not sure if this is a change in terraform behavior or if it's due to
expanded regions but with auto networks we have issues of overlapping
subnets when we deploy cf.