### PR TITLE
CI: Use bosh-deployment and terraform

### DIFF
--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -23,30 +23,10 @@ google_json_key_data: |
 # The following configuration values are names of resources that will be
 # automatically created and destroyed in the pipeline. They must not conflict
 # with existing resources in {{google_project}}
-# Name of a service account that will be used in integration tests
-google_service_account: google-cpi-ci-service-account
 # Name of an auto-configured network in {{google_project}}
 google_auto_network: google-cpi-ci-auto-network
 # Name of a manually-configured network in {{google_project}}
 google_network: google-cpi-ci-network
-# Name of a manually-configured subnetwork in {{google_network}}
-google_subnetwork: google-cpi-ci-subnetwork
-# Name of firewall for internal access
-google_firewall_internal: google-cpi-ci-firewall-internal
-# Name of firewall for external access
-google_firewall_external: google-cpi-ci-firewall-external
-# Name of an external IP address used in integration tests
-google_address_int: google-cpi-ci-ip-int-ubuntu
-# Name of an external IP address used in BATS tests
-google_address_bats: google-cpi-ci-ip-bats-ubuntu
-# Name of an external IP address used to create a director
-google_address_director: google-cpi-ci-ip-director-ubuntu
-# Name of a network target pool
-google_target_pool: google-cpi-ci-target-pool
-# Name of a backend service
-google_backend_service: google-cpi-ci-backend-service
-# Name of a region backend service
-google_region_backend_service: google-cpi-ci-regional-backend-service
 
 # Networking configuration
 # The CIDR range of {{google_subnetwork}}
@@ -72,9 +52,3 @@ private_key_user: vcap
 private_key_data: |
   # Contents of a private key whose public key component is set as a project-wide SSH
   # key in {{google_project}}
-bat_vcap_password: # A password to use for bats
-
-# Do not change
-director_username: admin
-director_password: admin
-

--- a/ci/credentials.yml.tpl
+++ b/ci/credentials.yml.tpl
@@ -36,11 +36,11 @@ google_firewall_internal: google-cpi-ci-firewall-internal
 # Name of firewall for external access
 google_firewall_external: google-cpi-ci-firewall-external
 # Name of an external IP address used in integration tests
-google_address_int_ubuntu: google-cpi-ci-ip-int-ubuntu
+google_address_int: google-cpi-ci-ip-int-ubuntu
 # Name of an external IP address used in BATS tests
-google_address_bats_ubuntu: google-cpi-ci-ip-bats-ubuntu
+google_address_bats: google-cpi-ci-ip-bats-ubuntu
 # Name of an external IP address used to create a director
-google_address_director_ubuntu: google-cpi-ci-ip-director-ubuntu
+google_address_director: google-cpi-ci-ip-director-ubuntu
 # Name of a network target pool
 google_target_pool: google-cpi-ci-target-pool
 # Name of a backend service
@@ -57,15 +57,15 @@ google_subnetwork_gw: 10.0.0.1
 # All of the following IP addresses must be within {{google_subnetwork}}'s CIDR
 # and be unique.
 # Three comma-delimited IP address in {{google_subnetwork}}
-google_address_static_int_ubuntu: 10.0.0.100,10.0.0.101,10.0.0.102
+google_address_static_int: 10.0.0.100,10.0.0.101,10.0.0.102
 # A private IP address in {{google_subnetwork}}
-google_address_static_director_ubuntu: 10.0.0.6
+google_address_static_director: 10.0.0.6
 # A private IP address in {{google_subnetwork}}
-google_address_static_bats_ubuntu: 10.0.0.20
+google_address_static_bats: 10.0.0.20
 # Two comma-delimited IP address in {{google_subnetwork}}
-google_address_static_pair_bats_ubuntu: 10.0.0.20,10.0.0.21
-# Hyphen-delimited range that contains {{google_address_static_pair_bats_ubuntu}} and {{google_address_static_bats_ubuntu}}
-google_address_static_bats_available_range_ubuntu: 10.0.0.20-10.0.0.30
+google_address_static_pair_bats: 10.0.0.20,10.0.0.21
+# Hyphen-delimited range that contains {{google_address_static_pair_bats}} and {{google_address_static_bats}}
+google_address_static_bats_available_range: 10.0.0.20-10.0.0.30
 
 # SSH and auth information
 private_key_user: vcap

--- a/ci/infrastructure/.gitignore
+++ b/ci/infrastructure/.gitignore
@@ -1,0 +1,2 @@
+terraform*
+.terraform/*

--- a/ci/infrastructure/inputs.tf
+++ b/ci/infrastructure/inputs.tf
@@ -1,0 +1,13 @@
+variable "google_project" {}
+
+variable "google_region" {}
+
+variable "google_zone" {}
+
+variable "google_json_key_data" {}
+
+variable "google_subnetwork_range" {}
+
+variable "google_firewall_internal" {}
+variable "google_firewall_external" {}
+variable "prefix" {}

--- a/ci/infrastructure/inputs.tf
+++ b/ci/infrastructure/inputs.tf
@@ -1,13 +1,10 @@
 variable "google_project" {}
-
 variable "google_region" {}
-
 variable "google_zone" {}
-
 variable "google_json_key_data" {}
-
 variable "google_subnetwork_range" {}
-
 variable "google_firewall_internal" {}
 variable "google_firewall_external" {}
 variable "prefix" {}
+variable "google_network" {}
+variable "google_auto_network" {}

--- a/ci/infrastructure/outputs.tf
+++ b/ci/infrastructure/outputs.tf
@@ -46,15 +46,15 @@ output "google_target_pool" {
   value = "${google_compute_target_pool.regional.name}"
 }
 
-output "google_address_director_ubuntu" {
+output "google_address_director" {
   value = "${google_compute_address.director.name}"
 }
 
-output "google_address_bats_ubuntu" {
+output "google_address_bats" {
   value = "${google_compute_address.bats.name}"
 }
 
-output "google_address_int_ubuntu" {
+output "google_address_int" {
   value = "${google_compute_address.int.name}"
 }
 

--- a/ci/infrastructure/outputs.tf
+++ b/ci/infrastructure/outputs.tf
@@ -46,16 +46,16 @@ output "google_target_pool" {
   value = "${google_compute_target_pool.regional.name}"
 }
 
-output "google_address_director" {
-  value = "${google_compute_address.director.name}"
+output "google_address_director_ip" {
+  value = "${google_compute_address.director.address}"
+
+
+output "google_address_bats_ip" {
+  value = "${google_compute_address.bats.address}"
 }
 
-output "google_address_bats" {
-  value = "${google_compute_address.bats.name}"
-}
-
-output "google_address_int" {
-  value = "${google_compute_address.int.name}"
+output "google_address_int_ip" {
+  value = "${google_compute_address.int.address}"
 }
 
 output "google_service_account" {

--- a/ci/infrastructure/outputs.tf
+++ b/ci/infrastructure/outputs.tf
@@ -48,7 +48,7 @@ output "google_target_pool" {
 
 output "google_address_director_ip" {
   value = "${google_compute_address.director.address}"
-
+}
 
 output "google_address_bats_ip" {
   value = "${google_compute_address.bats.address}"

--- a/ci/infrastructure/outputs.tf
+++ b/ci/infrastructure/outputs.tf
@@ -1,0 +1,63 @@
+output "google_project" {
+  value = "${var.google_project}"
+}
+
+output "google_region" {
+  value = "${var.google_region}"
+}
+
+output "google_zone" {
+  value = "${var.google_zone}"
+}
+
+output "google_json_key_data" {
+  value = "${var.google_json_key_data}"
+}
+
+output "google_auto_network" {
+  value = "${google_compute_network.auto.name}"
+}
+
+output "google_network" {
+  value = "${google_compute_network.manual.name}"
+}
+
+output "google_subnetwork" {
+  value = "${google_compute_subnetwork.subnetwork.name}"
+}
+
+output "google_firewall_internal" {
+  value = "${var.google_firewall_internal}"
+}
+
+output "google_firewall_external" {
+  value = "${var.google_firewall_external}"
+}
+
+output "google_backend_service" {
+  value = "${google_compute_backend_service.backend_service.name}"
+}
+
+output "google_region_backend_service" {
+  value = "${google_compute_region_backend_service.region_backend_service.name}"
+}
+
+output "google_target_pool" {
+  value = "${google_compute_target_pool.regional.name}"
+}
+
+output "google_address_director_ubuntu" {
+  value = "${google_compute_address.director.name}"
+}
+
+output "google_address_bats_ubuntu" {
+  value = "${google_compute_address.bats.name}"
+}
+
+output "google_address_int_ubuntu" {
+  value = "${google_compute_address.int.name}"
+}
+
+output "google_service_account" {
+  value = "${google_service_account.service_account.email}"
+}

--- a/ci/infrastructure/provider.tf
+++ b/ci/infrastructure/provider.tf
@@ -1,0 +1,11 @@
+provider "google" {
+  version = "v1.5.0"
+
+  project     = "${var.google_project}"
+  region      = "${var.google_region}"
+  credentials = "${var.google_json_key_data}"
+}
+
+provider "random" {
+  version = "~> 1.1.0"
+}

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -73,6 +73,10 @@ resource "google_compute_firewall" "external" {
     protocol = "udp"
     ports    = ["53"]
   }
+
+  allow {
+    protocol = "icmp"
+  }
 }
 
 # Target Pool

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -38,12 +38,6 @@ resource "google_compute_subnetwork" "subnetwork" {
   network       = "${google_compute_network.manual.self_link}"
 }
 
-resource "google_compute_subnetwork" "subnetwork_hack" {
-  name          = "${var.prefix}-hack"
-  ip_cidr_range = "10.100.0.0/24"
-  network       = "${google_compute_network.manual.self_link}"
-}
-
 resource "google_compute_firewall" "internal" {
   name        = "${var.prefix}-int"
   description = "BOSH CI Internal Traffic"
@@ -142,7 +136,7 @@ resource "google_compute_instance" "hack" {
   name         = "${var.prefix}-hack"
 
   network_interface = {
-    subnetwork = "${google_compute_subnetwork.subnetwork_hack.self_link}"
+    subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
   }
 
   zone = "${var.google_zone}"

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -1,0 +1,151 @@
+resource "random_string" "account_suffix" {
+  length  = 4
+  upper   = false
+  special = false
+  lower   = true
+  number  = true
+}
+
+resource "google_service_account" "service_account" {
+  account_id = "${var.prefix}-sa-${random_string.account_suffix.result}"
+}
+
+resource "google_compute_address" "director" {
+  name = "${var.prefix}-dir"
+}
+
+resource "google_compute_address" "bats" {
+  name = "${var.prefix}-bats"
+}
+
+resource "google_compute_address" "int" {
+  name = "${var.prefix}-int"
+}
+
+resource "google_compute_network" "auto" {
+  name                    = "${var.prefix}-auto"
+  auto_create_subnetworks = true
+}
+
+resource "google_compute_network" "manual" {
+  name                    = "${var.prefix}"
+  auto_create_subnetworks = false
+}
+
+resource "google_compute_subnetwork" "subnetwork" {
+  name          = "${var.prefix}"
+  ip_cidr_range = "${var.google_subnetwork_range}"
+  network       = "${google_compute_network.manual.self_link}"
+}
+
+resource "google_compute_firewall" "internal" {
+  name        = "${var.prefix}-int"
+  description = "BOSH CI Internal Traffic"
+  network     = "${google_compute_network.manual.self_link}"
+  source_tags = ["${var.google_firewall_internal}"]
+  target_tags = ["${var.google_firewall_internal}"]
+
+  allow {
+    protocol = "tcp"
+  }
+
+  allow {
+    protocol = "udp"
+  }
+
+  allow {
+    protocol = "icmp"
+  }
+}
+
+resource "google_compute_firewall" "external" {
+  name        = "${var.prefix}-ext"
+  description = "BOSH CI External Traffic"
+  network     = "${google_compute_network.manual.self_link}"
+  target_tags = ["${var.google_firewall_external}"]
+
+  allow {
+    protocol = "tcp"
+    ports    = ["22", "443", "4222", "6868", "25250", "25555", "25777"]
+  }
+
+  allow {
+    protocol = "udp"
+    ports    = ["53"]
+  }
+}
+
+# Target Pool
+resource "google_compute_target_pool" "regional" {
+  name   = "${var.prefix}-r"
+  region = "${var.google_region}"
+}
+
+# Backend Service
+resource "google_compute_instance_group" "backend_service" {
+  name = "${var.prefix}"
+  zone = "${var.google_zone}"
+}
+
+resource "google_compute_http_health_check" "backend_service" {
+  name = "${var.prefix}"
+}
+
+resource "google_compute_backend_service" "backend_service" {
+  health_checks = ["${google_compute_http_health_check.backend_service.self_link}"]
+  name          = "${var.prefix}"
+  port_name     = "http"
+  timeout_sec   = "30"
+
+  backend {
+    group           = "${google_compute_instance_group.backend_service.self_link}"
+    balancing_mode  = "UTILIZATION"
+    capacity_scaler = "1"
+    max_utilization = "0.8"
+  }
+}
+
+# Regional Backend Service
+resource "google_compute_health_check" "region_backend_service" {
+  name = "${var.prefix}-r"
+
+  tcp_health_check {
+    port = "8080"
+  }
+}
+
+resource "google_compute_instance_group" "region_backend_service" {
+  name      = "${var.prefix}-r"
+  zone      = "${var.google_zone}"
+  instances = ["${google_compute_instance.hack.self_link}"]
+}
+
+// HACK to work around: googleapi: Error 400: Invalid value for field 'resource.backends[0].group': 'https://www.googleapis.com/compute/v1/projects/pivotal-cloudfoundry/zones/us-west1-a/instanceGroups/ci-bosh-deployment-r'. Instance group must have a network to be attached to a backend service. Add an instance to give the instance group a network., invalid
+resource "google_compute_instance" "hack" {
+  boot_disk = {
+    initialize_params {
+      image = "debian-cloud/debian-8"
+    }
+  }
+
+  machine_type = "f1-micro"
+  name         = "${var.prefix}-hack"
+
+  network_interface = {
+    subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
+  }
+
+  zone = "${var.google_zone}"
+}
+
+resource "google_compute_region_backend_service" "region_backend_service" {
+  name          = "${var.prefix}-r"
+  health_checks = ["${google_compute_health_check.region_backend_service.self_link}"]
+  region        = "${var.google_region}"
+  protocol      = "TCP"
+  timeout_sec   = "30"
+
+  backend {
+    group = "${google_compute_instance_group.region_backend_service.self_link}"
+  }
+}

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -137,6 +137,7 @@ resource "google_compute_instance" "hack" {
 
   network_interface = {
     subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
+    address    = "10.0.0.254"
   }
 
   zone = "${var.google_zone}"

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -23,12 +23,12 @@ resource "google_compute_address" "int" {
 }
 
 resource "google_compute_network" "auto" {
-  name                    = "${var.prefix}-auto"
+  name                    = "${var.google_auto_network}"
   auto_create_subnetworks = true
 }
 
 resource "google_compute_network" "manual" {
-  name                    = "${var.prefix}"
+  name                    = "${var.google_network}"
   auto_create_subnetworks = false
 }
 

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -38,6 +38,12 @@ resource "google_compute_subnetwork" "subnetwork" {
   network       = "${google_compute_network.manual.self_link}"
 }
 
+resource "google_compute_subnetwork" "subnetwork_hack" {
+  name          = "${var.prefix}-hack"
+  ip_cidr_range = "10.100.0.0/24"
+  network       = "${google_compute_network.manual.self_link}"
+}
+
 resource "google_compute_firewall" "internal" {
   name        = "${var.prefix}-int"
   description = "BOSH CI Internal Traffic"
@@ -136,7 +142,7 @@ resource "google_compute_instance" "hack" {
   name         = "${var.prefix}-hack"
 
   network_interface = {
-    subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
+    subnetwork = "${google_compute_subnetwork.subnetwork_hack.self_link}"
   }
 
   zone = "${var.google_zone}"

--- a/ci/infrastructure/resources.tf
+++ b/ci/infrastructure/resources.tf
@@ -137,7 +137,6 @@ resource "google_compute_instance" "hack" {
 
   network_interface = {
     subnetwork = "${google_compute_subnetwork.subnetwork.self_link}"
-    address    = "10.0.0.254"
   }
 
   zone = "${var.google_zone}"

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -43,50 +43,48 @@ jobs:
     plan:
       - aggregate:
         - {trigger: true, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
-        - {trigger: true,                            get: stemcell, resource: google-ubuntu-stemcell}
+        - {trigger: true,                            get: stemcell,     resource: google-ubuntu-stemcell}
 
       - task: teardown-infrastructure
         file: bosh-cpi-src/ci/tasks/teardown-infrastructure.yml
-        config:
-          params:
-            google_project:                 {{google_project}}
-            google_region:                  {{google_region}}
-            google_zone:                    {{google_zone}}
-            google_json_key_data:           {{google_json_key_data}}
-            google_auto_network:            {{google_auto_network}}
-            google_network:                 {{google_network}}
-            google_subnetwork:              {{google_subnetwork}}
-            google_firewall_internal:       {{google_firewall_internal}}
-            google_firewall_external:       {{google_firewall_external}}
-            google_backend_service:         {{google_backend_service}}
-            google_region_backend_service:  {{google_region_backend_service}}
-            google_target_pool:             {{google_target_pool}}
-            google_address_director_ubuntu: {{google_address_director_ubuntu}}
-            google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-            google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-            google_service_account:         {{google_service_account}}
+        params:
+          google_project:                 {{google_project}}
+          google_region:                  {{google_region}}
+          google_zone:                    {{google_zone}}
+          google_json_key_data:           {{google_json_key_data}}
+          google_auto_network:            {{google_auto_network}}
+          google_network:                 {{google_network}}
+          google_subnetwork:              {{google_subnetwork}}
+          google_firewall_internal:       {{google_firewall_internal}}
+          google_firewall_external:       {{google_firewall_external}}
+          google_backend_service:         {{google_backend_service}}
+          google_region_backend_service:  {{google_region_backend_service}}
+          google_target_pool:             {{google_target_pool}}
+          google_address_director_ubuntu: {{google_address_director_ubuntu}}
+          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
+          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
+          google_service_account:         {{google_service_account}}
 
       - task: setup-infrastructure
         file: bosh-cpi-src/ci/tasks/setup-infrastructure.yml
-        config:
-          params:
-            google_project:                 {{google_project}}
-            google_region:                  {{google_region}}
-            google_zone:                    {{google_zone}}
-            google_json_key_data:           {{google_json_key_data}}
-            google_auto_network:            {{google_auto_network}}
-            google_network:                 {{google_network}}
-            google_subnetwork:              {{google_subnetwork}}
-            google_subnetwork_range:        {{google_subnetwork_range}}
-            google_firewall_internal:       {{google_firewall_internal}}
-            google_firewall_external:       {{google_firewall_external}}
-            google_backend_service:         {{google_backend_service}}
-            google_region_backend_service:  {{google_region_backend_service}}
-            google_target_pool:             {{google_target_pool}}
-            google_address_director_ubuntu: {{google_address_director_ubuntu}}
-            google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-            google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-            google_service_account:         {{google_service_account}}
+        params:
+          google_project:                 {{google_project}}
+          google_region:                  {{google_region}}
+          google_zone:                    {{google_zone}}
+          google_json_key_data:           {{google_json_key_data}}
+          google_auto_network:            {{google_auto_network}}
+          google_network:                 {{google_network}}
+          google_subnetwork:              {{google_subnetwork}}
+          google_subnetwork_range:        {{google_subnetwork_range}}
+          google_firewall_internal:       {{google_firewall_internal}}
+          google_firewall_external:       {{google_firewall_external}}
+          google_backend_service:         {{google_backend_service}}
+          google_region_backend_service:  {{google_region_backend_service}}
+          google_target_pool:             {{google_target_pool}}
+          google_address_director_ubuntu: {{google_address_director_ubuntu}}
+          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
+          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
+          google_service_account:         {{google_service_account}}
 
   - name: teardown-infrastructure
     serial_groups: [run-bats,run-int]
@@ -96,24 +94,23 @@ jobs:
 
       - task: teardown-infrastructure
         file: bosh-cpi-src/ci/tasks/teardown-infrastructure.yml
-        config:
-          params:
-            google_project:                 {{google_project}}
-            google_region:                  {{google_region}}
-            google_zone:                    {{google_zone}}
-            google_json_key_data:           {{google_json_key_data}}
-            google_auto_network:            {{google_auto_network}}
-            google_network:                 {{google_network}}
-            google_subnetwork:              {{google_subnetwork}}
-            google_firewall_internal:       {{google_firewall_internal}}
-            google_firewall_external:       {{google_firewall_external}}
-            google_backend_service:         {{google_backend_service}}
-            google_region_backend_service:  {{google_region_backend_service}}
-            google_target_pool:             {{google_target_pool}}
-            google_address_director_ubuntu: {{google_address_director_ubuntu}}
-            google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-            google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-            google_service_account:         {{google_service_account}}
+        params:
+          google_project:                 {{google_project}}
+          google_region:                  {{google_region}}
+          google_zone:                    {{google_zone}}
+          google_json_key_data:           {{google_json_key_data}}
+          google_auto_network:            {{google_auto_network}}
+          google_network:                 {{google_network}}
+          google_subnetwork:              {{google_subnetwork}}
+          google_firewall_internal:       {{google_firewall_internal}}
+          google_firewall_external:       {{google_firewall_external}}
+          google_backend_service:         {{google_backend_service}}
+          google_region_backend_service:  {{google_region_backend_service}}
+          google_target_pool:             {{google_target_pool}}
+          google_address_director_ubuntu: {{google_address_director_ubuntu}}
+          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
+          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
+          google_service_account:         {{google_service_account}}
 
   - name: deploy-ubuntu
     serial_groups: [run-bats]
@@ -123,11 +120,29 @@ jobs:
         - {trigger: true,  passed: [build-candidate],                       get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts}
         - {trigger: true, passed: [setup-infrastructure],                   get: stemcell, resource: google-ubuntu-stemcell}
         - {trigger: false,                                                  get: bosh-cli}
-        - {trigger: false,                                                  get: bosh-release}
+        - {trigger: false,                                                  get: bosh-deployment}
 
       - task: setup-director
         file: bosh-cpi-src/ci/tasks/setup-director.yml
-        config:
+        params:
+          google_project:                 {{google_project}}
+          google_region:                  {{google_region}}
+          google_zone:                    {{google_zone}}
+          google_json_key_data:           {{google_json_key_data}}
+          google_test_bucket_name:        {{google_test_bucket_name}}
+          google_network:                 {{google_network}}
+          google_subnetwork:              {{google_subnetwork}}
+          google_subnetwork_range:        {{google_subnetwork_range}}
+          google_subnetwork_gw:           {{google_subnetwork_gw}}
+          google_firewall_internal:       {{google_firewall_internal}}
+          google_firewall_external:       {{google_firewall_external}}
+          google_address_director:        {{google_address_director_ubuntu}}
+          google_address_static_director: {{google_address_static_director_ubuntu}}
+          private_key_user:               {{private_key_user}}
+          private_key_data:               {{private_key_data}}
+        on_failure:
+          task: teardown-director
+          file: bosh-cpi-src/ci/tasks/teardown-director.yml
           params:
             google_project:                 {{google_project}}
             google_region:                  {{google_region}}
@@ -144,30 +159,6 @@ jobs:
             google_address_static_director: {{google_address_static_director_ubuntu}}
             private_key_user:               {{private_key_user}}
             private_key_data:               {{private_key_data}}
-            director_username:              {{director_username}}
-            director_password:              {{director_password}}
-        on_failure:
-          task: teardown-director
-          file: bosh-cpi-src/ci/tasks/teardown-director.yml
-          config:
-            params:
-              google_project:                 {{google_project}}
-              google_region:                  {{google_region}}
-              google_zone:                    {{google_zone}}
-              google_json_key_data:           {{google_json_key_data}}
-              google_test_bucket_name:        {{google_test_bucket_name}}
-              google_network:                 {{google_network}}
-              google_subnetwork:              {{google_subnetwork}}
-              google_subnetwork_range:        {{google_subnetwork_range}}
-              google_subnetwork_gw:           {{google_subnetwork_gw}}
-              google_firewall_internal:       {{google_firewall_internal}}
-              google_firewall_external:       {{google_firewall_external}}
-              google_address_director:        {{google_address_director_ubuntu}}
-              google_address_static_director: {{google_address_static_director_ubuntu}}
-              private_key_user:               {{private_key_user}}
-              private_key_data:               {{private_key_data}}
-              director_username:              {{director_username}}
-              director_password:              {{director_password}}
       - put: director-creds
         params: {file: director-creds/creds.yml}
 
@@ -183,29 +174,25 @@ jobs:
 
       - task: run-bats
         file: bosh-cpi-src/ci/tasks/run-bats.yml
-        config:
-          params:
-            google_project:                             {{google_project}}
-            google_region:                              {{google_region}}
-            google_zone:                                {{google_zone}}
-            google_json_key_data:                       {{google_json_key_data}}
-            google_network:                             {{google_network}}
-            google_subnetwork:                          {{google_subnetwork}}
-            google_subnetwork_range:                    {{google_subnetwork_range}}
-            google_subnetwork_gw:                       {{google_subnetwork_gw}}
-            google_firewall_internal:                   {{google_firewall_internal}}
-            google_firewall_external:                   {{google_firewall_external}}
-            google_address_director:                    {{google_address_director_ubuntu}}
-            google_address_bats:                        {{google_address_bats_ubuntu}}
-            google_address_static_bats:                 {{google_address_static_bats_ubuntu}}
-            google_address_static_available_range_bats: {{google_address_static_bats_available_range_ubuntu}}
-            google_address_static_pair_bats:            {{google_address_static_pair_bats_ubuntu}}
-            base_os:                                    Ubuntu
-            stemcell_name:                              bosh-google-kvm-ubuntu-trusty-go_agent
-            bat_vcap_password:                          {{bat_vcap_password}}
-            private_key_data:                           {{private_key_data}}
-            director_username:                          {{director_username}}
-            director_password:                          {{director_password}}
+        params:
+          google_project:                             {{google_project}}
+          google_region:                              {{google_region}}
+          google_zone:                                {{google_zone}}
+          google_json_key_data:                       {{google_json_key_data}}
+          google_network:                             {{google_network}}
+          google_subnetwork:                          {{google_subnetwork}}
+          google_subnetwork_range:                    {{google_subnetwork_range}}
+          google_subnetwork_gw:                       {{google_subnetwork_gw}}
+          google_firewall_internal:                   {{google_firewall_internal}}
+          google_firewall_external:                   {{google_firewall_external}}
+          google_address_director:                    {{google_address_director_ubuntu}}
+          google_address_bats:                        {{google_address_bats_ubuntu}}
+          google_address_static_bats:                 {{google_address_static_bats_ubuntu}}
+          google_address_static_available_range_bats: {{google_address_static_bats_available_range_ubuntu}}
+          google_address_static_pair_bats:            {{google_address_static_pair_bats_ubuntu}}
+          base_os:                                    Ubuntu
+          stemcell_name:                              bosh-google-kvm-ubuntu-trusty-go_agent
+          private_key_data:                           {{private_key_data}}
 
   - name: run-int
     serial_groups: [run-int]
@@ -216,24 +203,22 @@ jobs:
 
       - task: run-int
         file: bosh-cpi-src/ci/tasks/run-int.yml
-        config:
-          params:
-            google_project:                   {{google_project}}
-            google_region:                    {{google_region}}
-            google_zone:                      {{google_zone}}
-            google_json_key_data:             {{google_json_key_data}}
-            google_auto_network:              {{google_auto_network}}
-            google_network:                   {{google_network}}
-            google_subnetwork:                {{google_subnetwork}}
-            google_firewall_internal:         {{google_firewall_internal}}
-            google_firewall_external:         {{google_firewall_external}}
-            google_address_int:               {{google_address_int_ubuntu}}
-            google_address_static_int:        {{google_address_static_int_ubuntu}}
-            google_target_pool:               {{google_target_pool}}
-            google_backend_service:           {{google_backend_service}}
-            google_region_backend_service:    {{google_region_backend_service}}
-            google_service_account:           {{google_service_account}}
-
+        params:
+          google_project:                   {{google_project}}
+          google_region:                    {{google_region}}
+          google_zone:                      {{google_zone}}
+          google_json_key_data:             {{google_json_key_data}}
+          google_auto_network:              {{google_auto_network}}
+          google_network:                   {{google_network}}
+          google_subnetwork:                {{google_subnetwork}}
+          google_firewall_internal:         {{google_firewall_internal}}
+          google_firewall_external:         {{google_firewall_external}}
+          google_address_int:               {{google_address_int_ubuntu}}
+          google_address_static_int:        {{google_address_static_int_ubuntu}}
+          google_target_pool:               {{google_target_pool}}
+          google_backend_service:           {{google_backend_service}}
+          google_region_backend_service:    {{google_region_backend_service}}
+          google_service_account:           {{google_service_account}}
 
 resources:
   - name: bosh-cpi-src-in
@@ -283,10 +268,11 @@ resources:
       bucket: bosh-cli-artifacts
       region_name: us-east-1
 
-  - name: bosh-release
-    type: bosh-io-release
+  - name: bosh-deployment
+    type: git
     source:
-      repository: cloudfoundry/bosh
+      uri: https://github.com/cloudfoundry/bosh-deployment.git
+      branch: master
 
   - name: bats
     type: git

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -168,6 +168,8 @@ jobs:
               private_key_data:               {{private_key_data}}
               director_username:              {{director_username}}
               director_password:              {{director_password}}
+      - put: director-creds
+        params: {file: director-creds/creds.yml}
 
   - name: run-bats
     serial: true
@@ -176,6 +178,7 @@ jobs:
       - aggregate:
         - {trigger: true, passed: [build-candidate, deploy-ubuntu], get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true, passed: [deploy-ubuntu],                  get: stemcell, resource: google-ubuntu-stemcell}
+        - {trigger: true, passed: [deploy-ubuntu],                  get: director-creds, resource: director-creds}
         - {trigger: false,                                          get: bats}
 
       - task: run-bats
@@ -201,6 +204,8 @@ jobs:
             stemcell_name:                              bosh-google-kvm-ubuntu-trusty-go_agent
             bat_vcap_password:                          {{bat_vcap_password}}
             private_key_data:                           {{private_key_data}}
+            director_username:                          {{director_username}}
+            director_password:                          {{director_password}}
 
   - name: run-int
     serial_groups: [run-int]
@@ -235,7 +240,7 @@ resources:
     type: git
     source:
       uri: https://github.com/cloudfoundry-incubator/bosh-google-cpi-release.git
-      branch: develop
+      branch: {{cpi_source_branch}}
       ignore_paths:
         - .final_builds/**/*.yml
         - releases/**/*.yml
@@ -253,6 +258,13 @@ resources:
       json_key: {{google_json_key_data}}
       bucket:   {{google_releases_bucket_name}}
       regexp:   bosh-google-cpi-([0-9]+\.[0-9]+\.[0-9]+)\.tgz.sha1
+
+  - name: director-creds
+    type: gcs-resource
+    source:
+      json_key:         {{google_json_key_data}}
+      bucket:           {{google_state_bucket_name}}
+      versioned_file:   creds.yml
 
   - name: version-semver
     type: semver

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -15,9 +15,10 @@ jobs:
     plan:
       - aggregate:
         - {trigger: true, get: bosh-cpi-src, resource: bosh-cpi-src-in}
-
-      - task: unit-tests
-        file: bosh-cpi-src/ci/tasks/unit-tests.yml
+# DO NOT CHECK IN
+#      - task: unit-tests
+#        file: bosh-cpi-src/ci/tasks/unit-tests.yml
+# DO NOT CHECK IN
 
   - name: build-candidate
     serial: true
@@ -39,78 +40,29 @@ jobs:
         params: {file: candidate/*.tgz.sha1}
 
   - name: setup-infrastructure
-    serial_groups: [run-bats,run-int]
+    serial_groups: [run-bats, run-int]
     plan:
       - aggregate:
         - {trigger: true, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
-        - {trigger: true,                            get: stemcell,     resource: google-ubuntu-stemcell}
-
-      - task: teardown-infrastructure
-        file: bosh-cpi-src/ci/tasks/teardown-infrastructure.yml
+        - {trigger: true,                            get: stemcell, resource: google-ubuntu-stemcell}
+      - put: infrastructure
         params:
-          google_project:                 {{google_project}}
-          google_region:                  {{google_region}}
-          google_zone:                    {{google_zone}}
-          google_json_key_data:           {{google_json_key_data}}
-          google_auto_network:            {{google_auto_network}}
-          google_network:                 {{google_network}}
-          google_subnetwork:              {{google_subnetwork}}
-          google_firewall_internal:       {{google_firewall_internal}}
-          google_firewall_external:       {{google_firewall_external}}
-          google_backend_service:         {{google_backend_service}}
-          google_region_backend_service:  {{google_region_backend_service}}
-          google_target_pool:             {{google_target_pool}}
-          google_address_director_ubuntu: {{google_address_director_ubuntu}}
-          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-          google_service_account:         {{google_service_account}}
-
-      - task: setup-infrastructure
-        file: bosh-cpi-src/ci/tasks/setup-infrastructure.yml
-        params:
-          google_project:                 {{google_project}}
-          google_region:                  {{google_region}}
-          google_zone:                    {{google_zone}}
-          google_json_key_data:           {{google_json_key_data}}
-          google_auto_network:            {{google_auto_network}}
-          google_network:                 {{google_network}}
-          google_subnetwork:              {{google_subnetwork}}
-          google_subnetwork_range:        {{google_subnetwork_range}}
-          google_firewall_internal:       {{google_firewall_internal}}
-          google_firewall_external:       {{google_firewall_external}}
-          google_backend_service:         {{google_backend_service}}
-          google_region_backend_service:  {{google_region_backend_service}}
-          google_target_pool:             {{google_target_pool}}
-          google_address_director_ubuntu: {{google_address_director_ubuntu}}
-          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-          google_service_account:         {{google_service_account}}
+          terraform_source: bosh-cpi-src/ci/infrastructure
+          delete_on_failure: true
 
   - name: teardown-infrastructure
-    serial_groups: [run-bats,run-int]
+    serial_groups: [run-bats, run-int]
     plan:
       - aggregate:
         - {trigger: true, passed: [run-bats, run-int], get: bosh-cpi-src, resource: bosh-cpi-src-in}
 
-      - task: teardown-infrastructure
-        file: bosh-cpi-src/ci/tasks/teardown-infrastructure.yml
+      - put: infrastructure
         params:
-          google_project:                 {{google_project}}
-          google_region:                  {{google_region}}
-          google_zone:                    {{google_zone}}
-          google_json_key_data:           {{google_json_key_data}}
-          google_auto_network:            {{google_auto_network}}
-          google_network:                 {{google_network}}
-          google_subnetwork:              {{google_subnetwork}}
-          google_firewall_internal:       {{google_firewall_internal}}
-          google_firewall_external:       {{google_firewall_external}}
-          google_backend_service:         {{google_backend_service}}
-          google_region_backend_service:  {{google_region_backend_service}}
-          google_target_pool:             {{google_target_pool}}
-          google_address_director_ubuntu: {{google_address_director_ubuntu}}
-          google_address_bats_ubuntu:     {{google_address_bats_ubuntu}}
-          google_address_int_ubuntu:      {{google_address_int_ubuntu}}
-          google_service_account:         {{google_service_account}}
+          terraform_source: bosh-cpi-src/ci/infrastructure
+          action: destroy
+        get_params:
+          terraform_source: bosh-cpi-src/ci/infrastructure
+          action: destroy
 
   - name: deploy-ubuntu
     serial_groups: [run-bats]
@@ -118,6 +70,7 @@ jobs:
       - aggregate:
         - {trigger: true, passed: [build-candidate, setup-infrastructure],  get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true,  passed: [build-candidate],                       get: bosh-cpi-release, resource: bosh-cpi-dev-artifacts}
+        - {trigger: true, passed: [setup-infrastructure],                   get: infrastructure, resource: infrastructure}
         - {trigger: true, passed: [setup-infrastructure],                   get: stemcell, resource: google-ubuntu-stemcell}
         - {trigger: false,                                                  get: bosh-cli}
         - {trigger: false,                                                  get: bosh-deployment}
@@ -125,38 +78,18 @@ jobs:
       - task: setup-director
         file: bosh-cpi-src/ci/tasks/setup-director.yml
         params:
-          google_project:                 {{google_project}}
-          google_region:                  {{google_region}}
-          google_zone:                    {{google_zone}}
-          google_json_key_data:           {{google_json_key_data}}
           google_test_bucket_name:        {{google_test_bucket_name}}
-          google_network:                 {{google_network}}
-          google_subnetwork:              {{google_subnetwork}}
           google_subnetwork_range:        {{google_subnetwork_range}}
           google_subnetwork_gw:           {{google_subnetwork_gw}}
-          google_firewall_internal:       {{google_firewall_internal}}
-          google_firewall_external:       {{google_firewall_external}}
-          google_address_director:        {{google_address_director_ubuntu}}
-          google_address_static_director: {{google_address_static_director_ubuntu}}
           private_key_user:               {{private_key_user}}
           private_key_data:               {{private_key_data}}
         on_failure:
           task: teardown-director
           file: bosh-cpi-src/ci/tasks/teardown-director.yml
           params:
-            google_project:                 {{google_project}}
-            google_region:                  {{google_region}}
-            google_zone:                    {{google_zone}}
-            google_json_key_data:           {{google_json_key_data}}
             google_test_bucket_name:        {{google_test_bucket_name}}
-            google_network:                 {{google_network}}
-            google_subnetwork:              {{google_subnetwork}}
             google_subnetwork_range:        {{google_subnetwork_range}}
             google_subnetwork_gw:           {{google_subnetwork_gw}}
-            google_firewall_internal:       {{google_firewall_internal}}
-            google_firewall_external:       {{google_firewall_external}}
-            google_address_director:        {{google_address_director_ubuntu}}
-            google_address_static_director: {{google_address_static_director_ubuntu}}
             private_key_user:               {{private_key_user}}
             private_key_data:               {{private_key_data}}
       - put: director-creds
@@ -175,19 +108,8 @@ jobs:
       - task: run-bats
         file: bosh-cpi-src/ci/tasks/run-bats.yml
         params:
-          google_project:                             {{google_project}}
-          google_region:                              {{google_region}}
-          google_zone:                                {{google_zone}}
-          google_json_key_data:                       {{google_json_key_data}}
-          google_network:                             {{google_network}}
-          google_subnetwork:                          {{google_subnetwork}}
           google_subnetwork_range:                    {{google_subnetwork_range}}
           google_subnetwork_gw:                       {{google_subnetwork_gw}}
-          google_firewall_internal:                   {{google_firewall_internal}}
-          google_firewall_external:                   {{google_firewall_external}}
-          google_address_director:                    {{google_address_director_ubuntu}}
-          google_address_bats:                        {{google_address_bats_ubuntu}}
-          google_address_static_bats:                 {{google_address_static_bats_ubuntu}}
           google_address_static_available_range_bats: {{google_address_static_bats_available_range_ubuntu}}
           google_address_static_pair_bats:            {{google_address_static_pair_bats_ubuntu}}
           base_os:                                    Ubuntu
@@ -200,25 +122,10 @@ jobs:
       - aggregate:
         - {trigger: true, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true, passed: [setup-infrastructure],                  get: stemcell, resource: google-ubuntu-stemcell}
+        - {trigger: true, passed: [setup-infrastructure],                  get: infrastructure, resource: infrastructure}
 
       - task: run-int
         file: bosh-cpi-src/ci/tasks/run-int.yml
-        params:
-          google_project:                   {{google_project}}
-          google_region:                    {{google_region}}
-          google_zone:                      {{google_zone}}
-          google_json_key_data:             {{google_json_key_data}}
-          google_auto_network:              {{google_auto_network}}
-          google_network:                   {{google_network}}
-          google_subnetwork:                {{google_subnetwork}}
-          google_firewall_internal:         {{google_firewall_internal}}
-          google_firewall_external:         {{google_firewall_external}}
-          google_address_int:               {{google_address_int_ubuntu}}
-          google_address_static_int:        {{google_address_static_int_ubuntu}}
-          google_target_pool:               {{google_target_pool}}
-          google_backend_service:           {{google_backend_service}}
-          google_region_backend_service:    {{google_region_backend_service}}
-          google_service_account:           {{google_service_account}}
 
 resources:
   - name: bosh-cpi-src-in
@@ -287,8 +194,32 @@ resources:
       force_regular: true
       tarball: true
 
-resource_types:
-  - name: gcs-resource
-    type: docker-image
+  - name: infrastructure
+    type: terraform
     source:
-      repository: frodenas/gcs-resource
+      storage:
+        bucket:            {{google_state_bucket_name}}
+        bucket_path:       terraform-{{cpi_source_branch}}
+        access_key_id:     {{google_state_access_key}}
+        secret_access_key: {{google_state_secret_key}}
+        region:            {{google_state_region}}
+        endpoint:          storage.googleapis.com
+      vars:
+        google_project:           {{google_project}}
+        google_region:            {{google_region}}
+        google_zone:              {{google_zone}}
+        google_json_key_data:     {{google_json_key_data}}
+        google_subnetwork_range:  {{google_subnetwork_range}}
+        google_firewall_internal: {{google_firewall_internal}}
+        google_firewall_external: {{google_firewall_external}}
+        prefix:                   {{cpi_source_branch}}
+
+resource_types:
+- name: gcs-resource
+  type: docker-image
+  source:
+    repository: frodenas/gcs-resource
+- name: terraform
+  type: docker-image
+  source:
+    repository: ljfranklin/terraform-resource

--- a/ci/pipeline-develop.yml
+++ b/ci/pipeline-develop.yml
@@ -45,19 +45,33 @@ jobs:
       - aggregate:
         - {trigger: true, passed: [build-candidate], get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true,                            get: stemcell, resource: google-ubuntu-stemcell}
+      - aggregate: &teardown_step
+        - task: teardown-infrastructure
+          file: bosh-cpi-src/ci/tasks/teardown-infrastructure.yml
+          params:
+            google_auto_network: {{google_auto_network}}
+            google_json_key_data: {{google_json_key_data}}
+            google_network: {{google_network}}
+            google_project: {{google_project}}
+            google_region: {{google_region}}
+            google_zone: {{google_zone}}
       - put: infrastructure
         params:
+          env_name: {{cpi_source_branch}}
           terraform_source: bosh-cpi-src/ci/infrastructure
           delete_on_failure: true
+      # delete VM created for regional backend service hack
+      - aggregate: *teardown_step
 
   - name: teardown-infrastructure
     serial_groups: [run-bats, run-int]
     plan:
       - aggregate:
         - {trigger: true, passed: [run-bats, run-int], get: bosh-cpi-src, resource: bosh-cpi-src-in}
-
+      - aggregate: *teardown_step
       - put: infrastructure
         params:
+          env_name: {{cpi_source_branch}}
           terraform_source: bosh-cpi-src/ci/infrastructure
           action: destroy
         get_params:
@@ -81,6 +95,8 @@ jobs:
           google_test_bucket_name:        {{google_test_bucket_name}}
           google_subnetwork_range:        {{google_subnetwork_range}}
           google_subnetwork_gw:           {{google_subnetwork_gw}}
+          google_address_static_director: {{google_address_static_director}}
+          google_json_key_data:           {{google_json_key_data}}
           private_key_user:               {{private_key_user}}
           private_key_data:               {{private_key_data}}
         on_failure:
@@ -90,6 +106,8 @@ jobs:
             google_test_bucket_name:        {{google_test_bucket_name}}
             google_subnetwork_range:        {{google_subnetwork_range}}
             google_subnetwork_gw:           {{google_subnetwork_gw}}
+            google_address_static_director: {{google_address_static_director}}
+            google_json_key_data:           {{google_json_key_data}}
             private_key_user:               {{private_key_user}}
             private_key_data:               {{private_key_data}}
       - put: director-creds
@@ -103,15 +121,17 @@ jobs:
         - {trigger: true, passed: [build-candidate, deploy-ubuntu], get: bosh-cpi-src, resource: bosh-cpi-src-in}
         - {trigger: true, passed: [deploy-ubuntu],                  get: stemcell, resource: google-ubuntu-stemcell}
         - {trigger: true, passed: [deploy-ubuntu],                  get: director-creds, resource: director-creds}
+        - {trigger: true, passed: [deploy-ubuntu],                  get: infrastructure, resource: infrastructure}
         - {trigger: false,                                          get: bats}
-
       - task: run-bats
         file: bosh-cpi-src/ci/tasks/run-bats.yml
         params:
           google_subnetwork_range:                    {{google_subnetwork_range}}
           google_subnetwork_gw:                       {{google_subnetwork_gw}}
-          google_address_static_available_range_bats: {{google_address_static_bats_available_range_ubuntu}}
-          google_address_static_pair_bats:            {{google_address_static_pair_bats_ubuntu}}
+          google_address_static_available_range_bats: {{google_address_static_bats_available_range}}
+          google_address_static_bats:                 {{google_address_static_bats}}
+          google_address_static_pair_bats:            {{google_address_static_pair_bats}}
+          google_json_key_data:                       {{google_json_key_data}}
           base_os:                                    Ubuntu
           stemcell_name:                              bosh-google-kvm-ubuntu-trusty-go_agent
           private_key_data:                           {{private_key_data}}
@@ -213,6 +233,8 @@ resources:
         google_firewall_internal: {{google_firewall_internal}}
         google_firewall_external: {{google_firewall_external}}
         prefix:                   {{cpi_source_branch}}
+        google_auto_network:      {{google_auto_network}}
+        google_network:           {{google_network}}
 
 resource_types:
 - name: gcs-resource

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -5,18 +5,9 @@ set -e
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
-check_param google_project
-check_param google_region
-check_param google_zone
 check_param google_json_key_data
-check_param google_network
-check_param google_subnetwork
 check_param google_subnetwork_range
 check_param google_subnetwork_gw
-check_param google_firewall_internal
-check_param google_firewall_external
-check_param google_address_director_ip
-check_param google_address_bats
 check_param google_address_static_bats
 check_param google_address_static_pair_bats
 check_param google_address_static_available_range_bats
@@ -32,6 +23,9 @@ cpi_release_name=bosh-google-cpi
 google_json_key=${deployment_dir}/google_key.json
 private_key=${deployment_dir}/private_key.pem
 bat_config_filename="${deployment_dir}/bat.yml"
+infrastructure_metadata="${PWD}/infrastructure/metadata"
+
+read_infrastructure
 
 echo "Setting up artifacts..."
 echo "${private_key_data}" > ${private_key}
@@ -87,7 +81,6 @@ cat > ${bat_config_filename} <<EOF
 ---
 cpi: google
 properties:
-  uuid: $(bosh status --uuid)
   stemcell:
     name: ${stemcell_name}
     version: latest

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -22,11 +22,7 @@ check_param google_address_static_pair_bats
 check_param google_address_static_available_range_bats
 check_param base_os
 check_param stemcell_name
-check_param bat_vcap_password
 check_param private_key_data
-check_param director_username
-check_param director_password
-
 
 # Initialize deployment artifacts
 deployment_dir="${PWD}"
@@ -35,9 +31,7 @@ creds_file="${creds_dir}/creds.yml"
 cpi_release_name=bosh-google-cpi
 google_json_key=${deployment_dir}/google_key.json
 private_key=${deployment_dir}/private_key.pem
-manifest_filename="director-manifest.yml"
-bat_manifest_filename="${deployment_dir}/${base_os}-bats-manifest.yml"
-bat_config_filename="${deployment_dir}/${base_os}-bats-config.yml"
+bat_config_filename="${deployment_dir}/bat.yml"
 
 echo "Setting up artifacts..."
 echo "${private_key_data}" > ${private_key}
@@ -50,14 +44,10 @@ echo "${private_key_data}" > ${private_key}
 
 export BAT_STEMCELL="${deployment_dir}/stemcell.tgz"
 export BAT_DEPLOYMENT_SPEC="${bat_config_filename}"
-export BAT_VCAP_PASSWORD="${bat_vcap_password}"
+export BAT_BOSH_CLI=/usr/bin/bosh2
+export BAT_DNS_HOST=${director_ip}
 export BAT_INFRASTRUCTURE=google
 export BAT_NETWORKING=dynamic
-export BAT_VCAP_PRIVATE_KEY=${private_key}
-# TODO(jrjohnson): add this to the image
-curl -o /usr/bin/bosh2 https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.28-linux-amd64
-chmod +x /usr/bin/bosh2
-export BAT_BOSH_CLI=/usr/bin/bosh2
 export BAT_PRIVATE_KEY=${private_key}
 
 echo "Creating google json key..."
@@ -86,125 +76,21 @@ eval $(ssh-agent)
 ssh-add ${private_key}
 
 echo "Using BOSH CLI version..."
-bosh version
-
-echo "Targeting BOSH director..."
-bosh -n target ${BAT_DIRECTOR}
+${BAT_BOSH_CLI} --version
 
 echo "Setting up BOSH v2..."
 export BOSH_ENVIRONMENT="${director_ip}"
-export BOSH_CLIENT="${director_username}"
-export BOSH_CLIENT_SECRET="${director_password}"
+export BOSH_CLIENT="admin"
+export BOSH_CLIENT_SECRET="=$(${BAT_BOSH_CLI} int ${creds_file} --path /admin_password)"
 export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
 
-echo "Creating ${bat_manifest_filename}..."
-cat > ${bat_manifest_filename} <<EOF
----
-name: <%= properties.name || "bat" %>
-director_uuid: <%= properties.uuid %>
-
-releases:
-  - name: bat
-    version: <%= properties.release || "latest" %>
-
-compilation:
-  workers: <%= properties.compilation_workers || 2 %>
-  network: default
-  reuse_compilation_vms: true
-  cloud_properties:
-    machine_type: <%= properties.machine_type || "n1-standard-2" %>
-    root_disk_size_gb: <%= properties.root_disk_size_gb || 20 %>
-    root_disk_type: <%= properties.root_disk_type || "pd-standard" %>
-    zone: <%= properties.zone %>
-
-update:
-  canaries: <%= properties.canaries || 1 %>
-  canary_watch_time: 3000-90000
-  update_watch_time: 3000-90000
-  max_in_flight: <%= properties.max_in_flight || 1 %>
-
-networks:
-  <% properties.networks.each do |network| %>
-  - name: <%= network.name %>
-    type: <%= network.type %>
-    subnets:
-      <% network.subnets.each do |subnet| %>
-      - range: <%= subnet.range %>
-        static: [<%= subnet.static %>]
-        gateway: <%= subnet.gateway %>
-        dns: <%= p('dns').inspect %>
-        cloud_properties:
-          network_name: <%= subnet.cloud_properties.network_name %>
-          subnetwork_name: <%= subnet.cloud_properties.subnetwork_name %>
-          ephemeral_external_ip: <%= subnet.cloud_properties.ephemeral_external_ip || false %>
-          tags: <%= subnet.cloud_properties.tags || [] %>
-      <% end %>
-  <% end %>
-  - name: static
-    type: vip
-
-resource_pools:
-  - name: common
-    network: default
-    stemcell:
-      name: <%= properties.stemcell.name %>
-      version: "<%= properties.stemcell.version %>"
-    cloud_properties:
-      machine_type: <%= properties.machine_type || "n1-standard-2" %>
-      root_disk_size_gb: <%= properties.root_disk_size_gb || 20 %>
-      root_disk_type: <%= properties.root_disk_type || "pd-standard" %>
-      zone: <%= properties.zone %>
-    <% if properties.password %>
-    env:
-      bosh:
-        password: <%= properties.password %>
-    <% end %>
-
-jobs:
-  - name: <%= properties.job || "batlight" %>
-    templates: <% (properties.templates || ["batlight"]).each do |template| %>
-    - name: <%= template %>
-    <% end %>
-    instances: <%= properties.instances %>
-    resource_pool: common
-    <% if properties.persistent_disk %>
-    persistent_disk: <%= properties.persistent_disk %>
-    <% end %>
-    networks:
-    <% properties.job_networks.each_with_index do |network, i| %>
-      - name: <%= network.name %>
-        <% if i == 0 %>
-        default: [dns, gateway]
-        static_ips:
-        <% properties.instances.times do |i| %>
-          - <%= properties.static_ips[i] %>
-        <% end %>
-        <% end %>
-    <% end %>
-    <% if properties.use_vip %>
-      - name: static
-        static_ips:
-          - <%= properties.vip %>
-    <% end %>
-
-properties:
-  batlight:
-    <% if properties.batlight.fail %>
-    fail: <%= properties.batlight.fail %>
-    <% end %>
-    <% if properties.batlight.missing %>
-    missing: <%= properties.batlight.missing %>
-    <% end %>
-    <% if properties.batlight.drain_type %>
-    drain_type: <%= properties.batlight.drain_type %>
-    <% end %>
-EOF
+echo "Testing connection to director"
+${BAT_BOSH_CLI} env
 
 echo "Creating ${bat_config_filename}..."
 cat > ${bat_config_filename} <<EOF
 ---
 cpi: google
-manifest_template_path: ${bat_manifest_filename}
 properties:
   uuid: $(bosh status --uuid)
   stemcell:
@@ -231,11 +117,11 @@ properties:
             - ${google_firewall_external}
 EOF
 
-
 pushd bats
   echo "Installing gems..."
   bundle install
 
   echo "Running BOSH Acceptance Tests..."
-  bundle exec rspec --tag ~multiple_manual_networks --tag ~raw_ephemeral_storage --tag ~changing_static_ip spec
+  # Disable Unsupported by google cpi (multiple_manual_networks) and deprecated specs
+  bundle exec rspec --tag ~multiple_manual_networks --tag ~raw_ephemeral_storage --tag ~changing_static_ip --tag ~network_reconfiguration spec
 popd

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -91,6 +91,12 @@ bosh version
 echo "Targeting BOSH director..."
 bosh -n target ${BAT_DIRECTOR}
 
+echo "Setting up BOSH v2..."
+export BOSH_ENVIRONMENT="${director_ip}"
+export BOSH_CLIENT="${director_username}"
+export BOSH_CLIENT_SECRET="${director_password}"
+export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
+
 echo "Creating ${bat_manifest_filename}..."
 cat > ${bat_manifest_filename} <<EOF
 ---
@@ -225,11 +231,6 @@ properties:
             - ${google_firewall_external}
 EOF
 
-
-export BOSH_ENVIRONMENT="${google_address_director}"
-export BOSH_CLIENT="${director_username}"
-export BOSH_CLIENT_SECRET="${director_password}"
-export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
 
 pushd bats
   echo "Installing gems..."

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -70,11 +70,12 @@ ${BAT_BOSH_CLI} --version
 echo "Setting up BOSH v2..."
 export BOSH_ENVIRONMENT="${google_address_director_ip}"
 export BOSH_CLIENT="admin"
-export BOSH_CLIENT_SECRET="=$(${BAT_BOSH_CLI} int ${creds_file} --path /admin_password)"
+export BOSH_CLIENT_SECRET="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
 export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
 
 echo "Testing connection to director"
 ${BAT_BOSH_CLI} env
+${BAT_BOSH_CLI} login
 
 echo "Creating ${bat_config_filename}..."
 cat > ${bat_config_filename} <<EOF

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -15,7 +15,7 @@ check_param google_subnetwork_range
 check_param google_subnetwork_gw
 check_param google_firewall_internal
 check_param google_firewall_external
-check_param google_address_director
+check_param google_address_director_ip
 check_param google_address_bats
 check_param google_address_static_bats
 check_param google_address_static_pair_bats
@@ -45,7 +45,7 @@ echo "${private_key_data}" > ${private_key}
 export BAT_STEMCELL="${deployment_dir}/stemcell.tgz"
 export BAT_DEPLOYMENT_SPEC="${bat_config_filename}"
 export BAT_BOSH_CLI=/usr/bin/bosh2
-export BAT_DNS_HOST=${director_ip}
+export BAT_DNS_HOST=${google_address_director_ip}
 export BAT_INFRASTRUCTURE=google
 export BAT_NETWORKING=dynamic
 export BAT_PRIVATE_KEY=${private_key}
@@ -61,13 +61,8 @@ gcloud config set project ${google_project}
 gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
 
-echo "Looking for director IP..."
-director_ip=$(gcloud compute addresses describe ${google_address_director} --format json | jq -r '.address')
-export BAT_DIRECTOR=${director_ip}
-export BAT_DNS_HOST=${director_ip}
-
-echo "Looking for bats IP..."
-bats_ip=$(gcloud compute addresses describe ${google_address_bats} --format json | jq -r '.address')
+export BAT_DIRECTOR=${google_address_director_ip}
+export BAT_DNS_HOST=${google_address_director_ip}
 
 echo "Creating private key..."
 echo "${private_key_data}" > ${private_key}
@@ -97,7 +92,7 @@ properties:
     name: ${stemcell_name}
     version: latest
   instances: 1
-  vip: ${bats_ip}
+  vip: ${google_address_bats_ip}
   zone: ${google_zone}
   static_ips: [${google_address_static_pair_bats}]
   networks:

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -74,7 +74,7 @@ echo "Using BOSH CLI version..."
 ${BAT_BOSH_CLI} --version
 
 echo "Setting up BOSH v2..."
-export BOSH_ENVIRONMENT="${director_ip}"
+export BOSH_ENVIRONMENT="${google_address_director_ip}"
 export BOSH_CLIENT="admin"
 export BOSH_CLIENT_SECRET="=$(${BAT_BOSH_CLI} int ${creds_file} --path /admin_password)"
 export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -56,7 +56,7 @@ gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
 
 export BAT_DIRECTOR=${google_address_director_ip}
-export BAT_DNS_HOST=${google_address_director_ip}
+export BAT_DNS_HOST=${google_address_static_director}
 
 echo "Creating private key..."
 echo "${private_key_data}" > ${private_key}

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -56,7 +56,7 @@ gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
 
 export BAT_DIRECTOR=${google_address_director_ip}
-export BAT_DNS_HOST=${google_address_static_director}
+export BAT_DNS_HOST=${google_address_director_ip}
 
 echo "Creating private key..."
 echo "${private_key_data}" > ${private_key}

--- a/ci/tasks/run-bats.sh
+++ b/ci/tasks/run-bats.sh
@@ -24,10 +24,14 @@ check_param base_os
 check_param stemcell_name
 check_param bat_vcap_password
 check_param private_key_data
+check_param director_username
+check_param director_password
 
 
 # Initialize deployment artifacts
 deployment_dir="${PWD}"
+creds_dir="${PWD}/director-creds"
+creds_file="${creds_dir}/creds.yml"
 cpi_release_name=bosh-google-cpi
 google_json_key=${deployment_dir}/google_key.json
 private_key=${deployment_dir}/private_key.pem
@@ -54,6 +58,7 @@ export BAT_VCAP_PRIVATE_KEY=${private_key}
 curl -o /usr/bin/bosh2 https://s3.amazonaws.com/bosh-cli-artifacts/bosh-cli-2.0.28-linux-amd64
 chmod +x /usr/bin/bosh2
 export BAT_BOSH_CLI=/usr/bin/bosh2
+export BAT_PRIVATE_KEY=${private_key}
 
 echo "Creating google json key..."
 echo "${google_json_key_data}" > ${google_json_key}
@@ -219,6 +224,12 @@ properties:
             - ${google_firewall_internal}
             - ${google_firewall_external}
 EOF
+
+
+export BOSH_ENVIRONMENT="${google_address_director}"
+export BOSH_CLIENT="${director_username}"
+export BOSH_CLIENT_SECRET="${director_password}"
+export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
 
 pushd bats
   echo "Installing gems..."

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -29,5 +29,4 @@ params:
   google_address_static_available_range_bats: replace-me
   base_os:                                    replace-me
   stemcell_name:                              replace-me
-  bat_vcap_password:                          replace-me
   private_key_data:                           replace-me

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -8,6 +8,7 @@ inputs:
   - name: bosh-cpi-src
   - name: stemcell
   - name: bats
+  - name: director-creds
 run:
   path: bosh-cpi-src/ci/tasks/run-bats.sh
 params:

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -22,7 +22,7 @@ params:
   google_subnetwork_gw:                       replace-me
   google_firewall_internal:                   replace-me
   google_firewall_external:                   replace-me
-  google_address_director:                    replace-me
+  google_address_director_ip:                 replace-me
   google_address_bats:                        replace-me
   google_address_static_bats:                 replace-me
   google_address_static_pair_bats:            replace-me

--- a/ci/tasks/run-bats.yml
+++ b/ci/tasks/run-bats.yml
@@ -9,21 +9,13 @@ inputs:
   - name: stemcell
   - name: bats
   - name: director-creds
+  - name: infrastructure
 run:
   path: bosh-cpi-src/ci/tasks/run-bats.sh
 params:
-  google_project:                             replace-me
-  google_region:                              replace-me
-  google_zone:                                replace-me
   google_json_key_data:                       replace-me
-  google_network:                             replace-me
-  google_subnetwork:                          replace-me
   google_subnetwork_range:                    replace-me
   google_subnetwork_gw:                       replace-me
-  google_firewall_internal:                   replace-me
-  google_firewall_external:                   replace-me
-  google_address_director_ip:                 replace-me
-  google_address_bats:                        replace-me
   google_address_static_bats:                 replace-me
   google_address_static_pair_bats:            replace-me
   google_address_static_available_range_bats: replace-me

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -5,21 +5,13 @@ set -e
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
-check_param google_project
-check_param google_region
-check_param google_zone
 check_param google_json_key_data
-check_param google_network
-check_param google_subnetwork
-check_param google_target_pool
-check_param google_backend_service
-check_param google_region_backend_service
-check_param google_address_static_int
-check_param google_address_int
-check_param google_service_account
 
 # Initialize deployment artifacts
 google_json_key=google_key.json
+infrastructure_metadata="${PWD}/infrastructure/metadata"
+
+read_infrastructure
 
 # Stemcell stuff
 export STEMCELL_VERSION=`cat stemcell/version`

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -6,6 +6,7 @@ source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
 check_param google_json_key_data
+check_param google_address_static_int
 
 # Initialize deployment artifacts
 google_json_key=google_key.json
@@ -32,7 +33,7 @@ export ILB_INSTANCE_GROUP=${google_region_backend_service}
 export ZONE=${google_zone}
 export REGION=${google_region}
 export GOOGLE_PROJECT=${google_project}
-export SERVICE_ACCOUNT=${google_service_account}@${google_project}.iam.gserviceaccount.com
+export SERVICE_ACCOUNT=${google_service_account}
 export CPI_ASYNC_DELETE=true
 
 echo "Creating google json key..."

--- a/ci/tasks/run-int.sh
+++ b/ci/tasks/run-int.sh
@@ -34,6 +34,7 @@ export ZONE=${google_zone}
 export REGION=${google_region}
 export GOOGLE_PROJECT=${google_project}
 export SERVICE_ACCOUNT=${google_service_account}
+export EXTERNAL_STATIC_IP=${google_address_int_ip}
 export CPI_ASYNC_DELETE=true
 
 echo "Creating google json key..."
@@ -46,14 +47,6 @@ gcloud auth activate-service-account --key-file $HOME/.config/gcloud/application
 gcloud config set project ${google_project}
 gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
-
-# Find external IP
-echo "Looking for external IP..."
-external_ip=$(gcloud compute addresses describe ${google_address_int} --format json | jq -r '.address')
-export EXTERNAL_STATIC_IP=${external_ip}
-
-# Export zone
-export ZONE=${google_zone}
 
 # Setup Go and run tests
 export GOPATH=${PWD}/bosh-cpi-src

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -9,18 +9,4 @@ inputs:
   - name: stemcell
 run:
   path: bosh-cpi-src/ci/tasks/run-int.sh
-params:
-  google_project:                replace-me
-  google_region:                 replace-me
-  google_zone:                   replace-me
-  google_network:                replace-me
-  google_subnetwork:             replace-me
-  google_auto_network:           replace-me
-  google_target_pool:            replace-me
-  google_address_int:            replace-me
-  google_address_static_int:     replace-me
-  google_backend_service:        replace-me
-  google_region_backend_service: replace-me
-  google_service_account:        replace-me
-  google_json_key_data: |
-    replace-me
+

--- a/ci/tasks/run-int.yml
+++ b/ci/tasks/run-int.yml
@@ -7,6 +7,8 @@ image_resource:
 inputs:
   - name: bosh-cpi-src
   - name: stemcell
+  - name: infrastructure
 run:
   path: bosh-cpi-src/ci/tasks/run-int.sh
-
+params:
+  google_json_key_data: replace-me

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -117,6 +117,7 @@ pushd ${deployment_dir}
       -o bosh-deployment/gcp/cpi.yml \
       -o bosh-deployment/gcp/gcs-blobstore.yml \
       -o bosh-deployment/external-ip-not-recommended.yml \
+      -o bosh-deployment/misc/powerdns.yml \
       -o ops_local_cpi.yml \
       -o ops_local_stemcell.yml \
       -o ops_add_vcap.yml \

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -135,13 +135,12 @@ pushd ${deployment_dir}
      --var-file director_gcs_credentials_json=${google_json_key} \
      --var-file agent_gcs_credentials_json=${google_json_key}
 
-  echo "Logging into BOSH Director"
-  ${BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca > ca_cert.pem
-  ${BOSH_CLI} alias-env micro-google --environment ${director_ip} --ca-cert ca_cert.pem
-
-  export BOSH_CLIENT=admin
-  export BOSH_CLIENT_SECRET=$(${BOSH_CLI} int ${creds_file} --path /admin_password)
-  ${BOSH_CLI} login -e micro-google
+  echo "Smoke testing connection to BOSH Director"
+  export BOSH_ENVIRONMENT="${google_address_director_ip}"
+  export BOSH_CLIENT="admin"
+  export BOSH_CLIENT_SECRET="=$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
+  export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
+  ${BOSH_CLI} env
 
   trap - ERR
   finish

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -65,7 +65,7 @@ cat > "${deployment_dir}/ops_local_cpi.yml" <<EOF
 - type: replace
   path: /releases/name=${cpi_release_name}?
   value:
-  - name: ${cpi_release_name}
+    name: ${cpi_release_name}
     url: file://${deployment_dir}/${cpi_release_name}.tgz
 EOF
 

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -11,6 +11,7 @@ check_param google_subnetwork_gw
 check_param private_key_user
 check_param private_key_data
 check_param google_json_key_data
+check_param google_address_static_director
 
 creds_dir="${PWD}/director-creds"
 creds_file="${creds_dir}/creds.yml"
@@ -75,7 +76,6 @@ cat > "${deployment_dir}/ops_local_stemcell.yml" <<EOF
   path: /resource_pools/name=vms/stemcell?
   value:
     url: ${deployment_dir}/stemcell.tgz
-end
 EOF
 
 # Allow user vcap to SSH into director
@@ -114,11 +114,8 @@ pushd ${deployment_dir}
   echo "Using bosh version..."
   ${BOSH_CLI} --version
 
-  echo "Generating certificates"
-  ${BOSH_CLI} interpolate ${creds_template} -v internal_ip=${director_ip} --vars-store ${creds_file}
-
   echo "Deploying BOSH Director..."
-  ${BOSH_CLI} create-env create-env bosh-deployment/bosh.yml \
+  ${BOSH_CLI} create-env bosh-deployment/bosh.yml \
       --state=${manifest_state_filename} \
       --vars-store=${creds_file} \
       -o bosh-deployment/gcp/cpi.yml \
@@ -133,7 +130,7 @@ pushd ${deployment_dir}
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
       -v zone=${google_region} \
-      -v tags=["${google_firewall_internal}", "${google_firewall_external}"] \
+      -v "tags=[${google_firewall_internal}, ${google_firewall_external}]" \
       -v network=${google_network} \
       -v subnetwork=${google_subnetwork} \
       -v bucket_name=${google_test_bucket_name} \

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -141,6 +141,7 @@ pushd ${deployment_dir}
   export BOSH_CLIENT_SECRET="=$(${BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
   export BOSH_CA_CERT="$(${BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
   ${BOSH_CLI} env
+  ${BOSH_CLI} login
 
   trap - ERR
   finish

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -121,6 +121,7 @@ pushd ${deployment_dir}
       -o ops_local_cpi.yml \
       -o ops_local_stemcell.yml \
       -o ops_add_vcap.yml \
+      -v dns_recursor_ip=169.254.169.254 \
       -v director_name=micro-google \
       -v internal_cidr=${google_subnetwork_range} \
       -v internal_gw=${google_subnetwork_gw} \

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -134,7 +134,8 @@ pushd ${deployment_dir}
       -v network=${google_network} \
       -v subnetwork=${google_subnetwork} \
       -v bucket_name=${google_test_bucket_name} \
-     --var-file director_gcs_credentials_json=${google_json_key}
+     --var-file director_gcs_credentials_json=${google_json_key} \
+     --var-file agent_gcs_credentials_json=${google_json_key}
 
   echo "Logging into BOSH Director"
   ${BOSH_CLI} interpolate --path /director_ssl/ca > ca_cert.pem

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -ue
 
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
@@ -138,8 +138,8 @@ pushd ${deployment_dir}
   echo "Smoke testing connection to BOSH Director"
   export BOSH_ENVIRONMENT="${google_address_director_ip}"
   export BOSH_CLIENT="admin"
-  export BOSH_CLIENT_SECRET="=$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
-  export BOSH_CA_CERT="$(${BAT_BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
+  export BOSH_CLIENT_SECRET="=$(${BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
+  export BOSH_CA_CERT="$(${BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
   ${BOSH_CLI} env
 
   trap - ERR

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -20,8 +20,6 @@ check_param google_address_director
 check_param google_address_static_director
 check_param private_key_user
 check_param private_key_data
-check_param director_password
-check_param director_username
 
 deployment_dir="${PWD}/deployment"
 creds_dir="${PWD}/director-creds"
@@ -34,9 +32,10 @@ manifest_state_filename="manifest-state.json"
 
 echo "Setting up artifacts..."
 cp ./bosh-cpi-release/*.tgz ${deployment_dir}/${cpi_release_name}.tgz
-cp ./bosh-release/*.tgz ${deployment_dir}/bosh-release.tgz
 cp ./stemcell/*.tgz ${deployment_dir}/stemcell.tgz
 cp ./bosh-cli/bosh-cli-* ${deployment_dir}/bosh && chmod +x ${deployment_dir}/bosh
+export BOSH_CLI=${deployment_dir}/bosh
+cp -r ./bosh-deployment ${deployment_dir}
 
 echo "Creating google json key..."
 echo "${google_json_key_data}" > ${google_json_key}
@@ -62,265 +61,48 @@ echo "Generating public key from vcap private"
 public_key="public.key"
 openssl rsa -in ${private_key} -pubout > ${public_key}
 
-# Export prefixed variables so they are accessible
-echo "Populating environment with BOSH_ prefixed vars"
 export BOSH_CONFIG=${deployment_dir}/.boshconfig
-export BOSH_director_username=$director_username
-export BOSH_director_password=$director_password
-export BOSH_cpi_release_name=$cpi_release_name
-export BOSH_google_zone=$google_zone
-export BOSH_google_project=$google_project
-export BOSH_google_address_static_director=$google_address_static_director
-export BOSH_director_ip=$director_ip
-export BOSH_google_test_bucket_name=$google_test_bucket_name
-export BOSH_google_network=$google_network
-export BOSH_google_subnetwork_gw=$google_subnetwork_gw
-export BOSH_google_subnetwork=$google_subnetwork
-export BOSH_google_subnetwork_range=$google_subnetwork_range
-export BOSH_google_firewall_internal=$google_firewall_internal
-export BOSH_google_firewall_external=$google_firewall_external
 
-export BOSH_google_json_key_data=$google_json_key_data
-
-echo "Creating ${manifest_filename}..."
-cat > "${deployment_dir}/${manifest_filename}"<<EOF
+echo "Creating ops files..."
+# Use the locally built CPI
+cat > "${deployment_dir}/ops_local_cpi.yml" <<EOF
 ---
-name: bosh
-releases:
-  - name: bosh
-    url: file://bosh-release.tgz
-  - name: ((cpi_release_name))
-    url: file://((cpi_release_name)).tgz
-  - name: os-conf
-    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=12
-    sha1: af5a2c9f228b9d7ec4bd051d71fef0e712fa1549
-
-resource_pools:
-  - name: vms
-    network: private
-    stemcell:
-      url: file://stemcell.tgz
-    cloud_properties:
-      zone: ((google_zone))
-      machine_type: n1-standard-2
-      root_disk_size_gb: 40
-      root_disk_type: pd-standard
-      service_scopes:
-        - compute
-        - devstorage.full_control
-
-disk_pools:
-  - name: disks
-    disk_size: 32_768
-    cloud_properties:
-      type: pd-standard
-
-networks:
-  - name: private
-    type: manual
-    subnets:
-    - range: ((google_subnetwork_range))
-      gateway: ((google_subnetwork_gw))
-      cloud_properties:
-        network_name: ((google_network))
-        subnetwork_name: ((google_subnetwork))
-        tags:
-          - ((google_firewall_internal))
-          - ((google_firewall_external))
-  - name: public
-    type: vip
-
-instance_groups:
-- name: bosh
-  instances: 1
-
-  jobs:
-  - name: nats
-    release: bosh
-  - name: postgres-9.4
-    release: bosh
-  - name: blobstore
-    release: bosh
-  - name: director
-    release: bosh
-  - name: health_monitor
-    release: bosh
-  - name: powerdns
-    release: bosh
-  - name: google_cpi
-    release: bosh-google-cpi
-  - name: user_add
-    release: os-conf
-
-  resource_pool: vms
-  persistent_disk_pool: disks
-
-  networks:
-    - name: private
-      static_ips: [((google_address_static_director))]
-      default:
-        - dns
-        - gateway
-    - name: public
-      static_ips:
-        - ((director_ip))
-
-  properties:
-    nats:
-      address: ((director_ip))
-      user: nats
-      password: nats-password
-      tls:
-        ca: ((nats_server_tls.ca))
-        client_ca:
-          certificate: ((nats_ca.certificate))
-          private_key: ((nats_ca.private_key))
-        server:
-          certificate: ((nats_server_tls.certificate))
-          private_key: ((nats_server_tls.private_key))
-        director:
-          certificate: ((nats_clients_director_tls.certificate))
-          private_key: ((nats_clients_director_tls.private_key))
-        health_monitor:
-          certificate: ((nats_clients_health_monitor_tls.certificate))
-          private_key: ((nats_clients_health_monitor_tls.private_key))
-    postgres: &db
-      listen_address: 127.0.0.1
-      host: 127.0.0.1
-      user: postgres
-      password: postgres-password
-      database: bosh
-      adapter: postgres
-
-    dns:
-      address: ((google_address_static_director))
-      domain_name: microbosh
-      db: *db
-      recursor: 169.254.169.254
-
-    registry:
-      address: ((google_address_static_director))
-      host: ((google_address_static_director))
-      db: *db
-      http:
-        user: registry
-
-    blobstore:
-      provider: gcs
-      bucket_name: ((google_test_bucket_name))
-      credentials_source: static
-      json_key: |
-        $(echo $google_json_key_data | tr -d '\n')
-      address: ((google_address_static_director))
-      director:
-        user: director
-        password: director-password
-      agent:
-        user: agent
-        password: agent-password
-      port: 25250
-
-    director:
-      address: 127.0.0.1
-      name: micro-google
-      db: *db
-      cpi_job: google_cpi
-      ssl:
-        key: ((director_ssl.private_key))
-        cert: ((director_ssl.certificate))
-      user_management:
-        provider: local
-        local:
-          users:
-            - name: ((director_username))
-              password: ((director_password))
-            - name: hm
-              password: hm-password
-    hm:
-      director_account:
-        user: hm
-        password: hm-password
-      resurrector_enabled: true
-
-    google: &google_properties
-      project: ((google_project))
-
-    users:
-      - name: vcap
-        public_key: $(ssh-keygen -i -m PKCS8 -f ${public_key})
-
-    agent:
-      mbus: nats://nats:nats-password@((google_address_static_director)):4222
-      ntp: *ntp
-      blobstore:
-          options:
-            endpoint: http://((google_address_static_director)):25250
-            user: agent
-            password: agent-password
-
-    ntp: &ntp
-      - 169.254.169.254
-
-cloud_provider:
-  template:
-    name: google_cpi
-    release: ((cpi_release_name))
-
-  mbus: https://mbus:mbus-password@((director_ip)):6868
-
-  properties:
-    google: *google_properties
-    agent: {mbus: "https://mbus:mbus-password@0.0.0.0:6868"}
-    blobstore: {provider: local, path: /var/vcap/micro_bosh/data/cache}
-    ntp: *ntp
-
-misc:
-  ca_cert: ((director_ssl.ca))
-
+- type: replace
+  path: /releases/name=bosh-google-cpi?
+  value:
+  - name: ${cpi_release_name}
+    url: file://${cpi_release_name}.tgz
 EOF
 
-creds_template=creds.yml.tpl
-echo "Creating ${creds_template}..."
-cat > "${deployment_dir}/${creds_template}"<<EOF
-variables:
-- name: default_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: bosh_ca
-- name: director_ssl
-  type: certificate
-  options:
-    ca: default_ca
-    common_name: ((internal_ip))
-    alternative_names: [((internal_ip))]
-- name: nats_ca
-  type: certificate
-  options:
-    is_ca: true
-    common_name: default.nats-ca.bosh-internal
-- name: nats_server_tls
-  type: certificate
-  options:
-    ca: nats_ca
-    common_name: default.nats.bosh-internal
-    alternative_names: [((internal_ip))]
-    extended_key_usage:
-    - server_auth
-- name: nats_clients_director_tls
-  type: certificate
-  options:
-    ca: nats_ca
-    common_name: default.director.bosh-internal
-    extended_key_usage:
-    - client_auth
-- name: nats_clients_health_monitor_tls
-  type: certificate
-  options:
-    ca: nats_ca
-    common_name: default.hm.bosh-internal
-    extended_key_usage:
-    - client_auth
+# Use locally sourced stemcell
+cat > "${deployment_dir}/ops_local_stemcell.yml" <<EOF
+---
+- type: replace
+  path: /resource_pools/name=vms/stemcell?
+  value:
+    url: ${deployment_dir}/stemcell.tgz
+end
+EOF
+
+# Allow user vcap to SSH into director
+cat > "${deployment_dir}/ops_add_vcap.yml" <<EOF
+- type: replace
+  path: /releases/name=os-conf?
+  value:
+    name: os-conf
+    version: 18
+    url: https://bosh.io/d/github.com/cloudfoundry/os-conf-release?v=18
+    sha1: 78d79f08ff5001cc2a24f572837c7a9c59a0e796
+
+- type: replace
+  path: /instance_groups/name=bosh/jobs/-
+  value:
+    name: user_add
+    release: os-conf
+    properties:
+      users:
+      - name: vcap
+        public_key: $(ssh-keygen -i -m PKCS8 -f ${public_key})
 EOF
 
 pushd ${deployment_dir}
@@ -335,25 +117,42 @@ pushd ${deployment_dir}
   trap finish ERR
 
   echo "Using bosh version..."
-  ./bosh --version
+  ${BOSH_CLI} --version
 
   echo "Generating certificates"
-  ./bosh interpolate ${creds_template} -v internal_ip=${director_ip} --vars-store ${creds_file}
+  ${BOSH_CLI} interpolate ${creds_template} -v internal_ip=${director_ip} --vars-store ${creds_file}
 
   echo "Deploying BOSH Director..."
-  ./bosh create-env ${manifest_filename} --state ${manifest_state_filename} --vars-store ${creds_file} --vars-env=BOSH
+  ${BOSH_CLI} create-env create-env bosh-deployment/bosh.yml \
+      --state=${manifest_state_filename} \
+      --vars-store=${creds_file} \
+      -o bosh-deployment/gcp/cpi.yml \
+      -o bosh-deployment/gcp/gcs-blobstore.yml \
+      -o ops_local_cpi.yml \
+      -o ops_local_stemcell.yml \
+      -o ops_add_vcap.yml \
+      -v director_name=micro-google \
+      -v internal_cidr=${google_subnetwork_range} \
+      -v internal_gw=${google_subnetwork_gw} \
+      -v internal_ip=${google_address_static_director} \
+      --var-file gcp_credentials_json=${google_json_key} \
+      -v project_id=${google_project} \
+      -v zone=${google_region} \
+      -v tags=["${google_firewall_internal}", "${google_firewall_external}"] \
+      -v network=${google_network} \
+      -v subnetwork=${google_subnetwork} \
+      -v bucket_name=${google_test_bucket_name} \
+     --var-file director_gcs_credentials_json=${google_json_key}
 
   echo "Logging into BOSH Director"
-  # We need to fetch and specify the CA certificate as bosh-cli V2
-  # strictly validates certificate with no insecure option.
-  ./bosh interpolate ${creds_file} --path /director_ssl/ca > ca_cert.pem
-  ./bosh alias-env micro-google --environment ${director_ip} --ca-cert ca_cert.pem
+  ${BOSH_CLI} interpolate --path /director_ssl/ca > ca_cert.pem
+  ${BOSH_CLI} alias-env micro-google --environment ${director_ip} --ca-cert ca_cert.pem
 
-  # We have to export these to get non-interactive login
-  export BOSH_CLIENT=$BOSH_director_username
-  export BOSH_CLIENT_SECRET=$BOSH_director_password
-  ./bosh login -e micro-google
-  
+  export BOSH_CLIENT=admin
+  export BOSH_CLIENT_SECRET=$(${BOSH_CLI} int ${creds_file} --path /admin_password)
+  ${BOSH_CLI} login -e micro-google
+
   trap - ERR
   finish
 popd
+

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -63,10 +63,10 @@ echo "Creating ops files..."
 cat > "${deployment_dir}/ops_local_cpi.yml" <<EOF
 ---
 - type: replace
-  path: /releases/name=bosh-google-cpi?
+  path: /releases/name=${cpi_release_name}?
   value:
   - name: ${cpi_release_name}
-    url: file://${cpi_release_name}.tgz
+    url: file://${deployment_dir}/${cpi_release_name}.tgz
 EOF
 
 # Use locally sourced stemcell
@@ -75,7 +75,7 @@ cat > "${deployment_dir}/ops_local_stemcell.yml" <<EOF
 - type: replace
   path: /resource_pools/name=vms/stemcell?
   value:
-    url: ${deployment_dir}/stemcell.tgz
+    url: file://${deployment_dir}/stemcell.tgz
 EOF
 
 # Allow user vcap to SSH into director

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -138,7 +138,7 @@ pushd ${deployment_dir}
   echo "Smoke testing connection to BOSH Director"
   export BOSH_ENVIRONMENT="${google_address_director_ip}"
   export BOSH_CLIENT="admin"
-  export BOSH_CLIENT_SECRET="=$(${BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
+  export BOSH_CLIENT_SECRET="$(${BOSH_CLI} interpolate ${creds_file} --path /admin_password)"
   export BOSH_CA_CERT="$(${BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca)"
   ${BOSH_CLI} env
   ${BOSH_CLI} login

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -10,34 +10,19 @@ check_param google_subnetwork_range
 check_param google_subnetwork_gw
 check_param private_key_user
 check_param private_key_data
+check_param google_json_key_data
 
-deployment_dir="${PWD}/deployment"
 creds_dir="${PWD}/director-creds"
 creds_file="${creds_dir}/creds.yml"
 cpi_release_name=bosh-google-cpi
-google_json_key=${deployment_dir}/google_key.json
-private_key=${deployment_dir}/private_key.pem
 manifest_filename="director-manifest.yml"
 manifest_state_filename="manifest-state.json"
 infrastructure_metadata="${PWD}/infrastructure/metadata"
+deployment_dir="${PWD}/deployment"
+google_json_key=${deployment_dir}/google_key.json
+private_key=${deployment_dir}/private_key.pem
 
-echo "Reading infrastructure values..."
-export google_project=$(cat ${infrastructure_metadata} | jq -r .google_project)
-export google_region=$(cat ${infrastructure_metadata} | jq -r .google_region)
-export google_zone=$(cat ${infrastructure_metadata} | jq -r .google_zone)
-export google_json_key_data=$(cat ${infrastructure_metadata} | jq -r .google_json_key_data)
-export google_auto_network=$(cat ${infrastructure_metadata} | jq -r .google_auto_network)
-export google_network=$(cat ${infrastructure_metadata} | jq -r .google_network)
-export google_subnetwork=$(cat ${infrastructure_metadata} | jq -r .google_subnetwork)
-export google_firewall_internal=$(cat ${infrastructure_metadata} | jq -r .google_firewall_internal)
-export google_firewall_external=$(cat ${infrastructure_metadata} | jq -r .google_firewall_external)
-export google_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_backend_service)
-export google_region_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_region_backend_service)
-export google_target_pool=$(cat ${infrastructure_metadata} | jq -r .google_target_pool)
-export google_address_director_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_director_ubuntu)
-export google_address_bats_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_bats_ubuntu)
-export google_address_int_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_int_ubuntu)
-export google_service_account=$(cat ${infrastructure_metadata} | jq -r .google_service_account)
+read_infrastructure
 
 echo "Setting up artifacts..."
 cp ./bosh-cpi-release/*.tgz ${deployment_dir}/${cpi_release_name}.tgz

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -5,19 +5,9 @@ set -e
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
-check_param google_project
-check_param google_region
-check_param google_zone
-check_param google_json_key_data
 check_param google_test_bucket_name
-check_param google_network
-check_param google_subnetwork
 check_param google_subnetwork_range
 check_param google_subnetwork_gw
-check_param google_firewall_internal
-check_param google_firewall_external
-check_param google_address_director
-check_param google_address_static_director
 check_param private_key_user
 check_param private_key_data
 
@@ -29,6 +19,25 @@ google_json_key=${deployment_dir}/google_key.json
 private_key=${deployment_dir}/private_key.pem
 manifest_filename="director-manifest.yml"
 manifest_state_filename="manifest-state.json"
+infrastructure_metadata="${PWD}/infrastructure/metadata"
+
+echo "Reading infrastructure values..."
+export google_project=$(cat ${infrastructure_metadata} | jq -r .google_project)
+export google_region=$(cat ${infrastructure_metadata} | jq -r .google_region)
+export google_zone=$(cat ${infrastructure_metadata} | jq -r .google_zone)
+export google_json_key_data=$(cat ${infrastructure_metadata} | jq -r .google_json_key_data)
+export google_auto_network=$(cat ${infrastructure_metadata} | jq -r .google_auto_network)
+export google_network=$(cat ${infrastructure_metadata} | jq -r .google_network)
+export google_subnetwork=$(cat ${infrastructure_metadata} | jq -r .google_subnetwork)
+export google_firewall_internal=$(cat ${infrastructure_metadata} | jq -r .google_firewall_internal)
+export google_firewall_external=$(cat ${infrastructure_metadata} | jq -r .google_firewall_external)
+export google_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_backend_service)
+export google_region_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_region_backend_service)
+export google_target_pool=$(cat ${infrastructure_metadata} | jq -r .google_target_pool)
+export google_address_director_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_director_ubuntu)
+export google_address_bats_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_bats_ubuntu)
+export google_address_int_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_int_ubuntu)
+export google_service_account=$(cat ${infrastructure_metadata} | jq -r .google_service_account)
 
 echo "Setting up artifacts..."
 cp ./bosh-cpi-release/*.tgz ${deployment_dir}/${cpi_release_name}.tgz

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -ue
+set -e
 
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -42,9 +42,6 @@ gcloud config set project ${google_project}
 gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
 
-echo "Looking for director IP..."
-director_ip=$(gcloud compute addresses describe ${google_address_director} --format json | jq -r '.address')
-
 echo "Creating private key..."
 echo "${private_key_data}" > ${private_key}
 chmod go-r ${private_key}
@@ -127,7 +124,7 @@ pushd ${deployment_dir}
       -v internal_cidr=${google_subnetwork_range} \
       -v internal_gw=${google_subnetwork_gw} \
       -v internal_ip=${google_address_static_director} \
-      -v external_ip=${director_ip} \
+      -v external_ip=${google_address_director_ip} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
       -v zone=${google_zone} \

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -80,6 +80,7 @@ EOF
 
 # Allow user vcap to SSH into director
 cat > "${deployment_dir}/ops_add_vcap.yml" <<EOF
+---
 - type: replace
   path: /releases/name=os-conf?
   value:

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -129,7 +129,7 @@ pushd ${deployment_dir}
       -v internal_ip=${google_address_static_director} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
-      -v zone=${google_region} \
+      -v zone=${google_zone} \
       -v "tags=[${google_firewall_internal}, ${google_firewall_external}]" \
       -v network=${google_network} \
       -v subnetwork=${google_subnetwork} \

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -136,7 +136,7 @@ pushd ${deployment_dir}
      --var-file agent_gcs_credentials_json=${google_json_key}
 
   echo "Logging into BOSH Director"
-  ${BOSH_CLI} interpolate --path /director_ssl/ca > ca_cert.pem
+  ${BOSH_CLI} interpolate ${creds_file} --path /director_ssl/ca > ca_cert.pem
   ${BOSH_CLI} alias-env micro-google --environment ${director_ip} --ca-cert ca_cert.pem
 
   export BOSH_CLIENT=admin

--- a/ci/tasks/setup-director.sh
+++ b/ci/tasks/setup-director.sh
@@ -13,8 +13,7 @@ check_param private_key_data
 check_param google_json_key_data
 check_param google_address_static_director
 
-creds_dir="${PWD}/director-creds"
-creds_file="${creds_dir}/creds.yml"
+creds_file="${PWD}/director-creds/creds.yml"
 cpi_release_name=bosh-google-cpi
 manifest_filename="director-manifest.yml"
 manifest_state_filename="manifest-state.json"
@@ -120,6 +119,7 @@ pushd ${deployment_dir}
       --vars-store=${creds_file} \
       -o bosh-deployment/gcp/cpi.yml \
       -o bosh-deployment/gcp/gcs-blobstore.yml \
+      -o bosh-deployment/external-ip-not-recommended.yml \
       -o ops_local_cpi.yml \
       -o ops_local_stemcell.yml \
       -o ops_add_vcap.yml \
@@ -127,6 +127,7 @@ pushd ${deployment_dir}
       -v internal_cidr=${google_subnetwork_range} \
       -v internal_gw=${google_subnetwork_gw} \
       -v internal_ip=${google_address_static_director} \
+      -v external_ip=${director_ip} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
       -v zone=${google_zone} \

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -17,18 +17,7 @@ run:
   path: bosh-cpi-src/ci/tasks/setup-director.sh
 params:
   BOSH_INIT_LOG_LEVEL:            warn
-  google_project:                 replace-me
-  google_region:                  replace-me
-  google_zone:                    replace-me
-  google_json_key_data:           replace-me
-  google_test_bucket_name:        replace-me
-  google_network:                 replace-me
-  google_subnetwork:              replace-me
   google_subnetwork_range:        replace-me
   google_subnetwork_gw:           replace-me
-  google_firewall_internal:       replace-me
-  google_firewall_external:       replace-me
-  google_address_director:        replace-me
-  google_address_static_director: replace-me
   private_key_user:               replace-me
   private_key_data:               replace-me

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -10,6 +10,7 @@ inputs:
   - name: bosh-deployment
   - name: stemcell
   - name: bosh-cli
+  - name: infrastructure
 outputs:
   - name: deployment
   - name: director-creds
@@ -21,3 +22,4 @@ params:
   google_subnetwork_gw:           replace-me
   private_key_user:               replace-me
   private_key_data:               replace-me
+  google_json_key_data:           replace-me

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -12,6 +12,7 @@ inputs:
   - name: bosh-cli
 outputs:
   - name: deployment
+  - name: director-creds
 run:
   path: bosh-cpi-src/ci/tasks/setup-director.sh
 params:

--- a/ci/tasks/setup-director.yml
+++ b/ci/tasks/setup-director.yml
@@ -7,7 +7,7 @@ image_resource:
 inputs:
   - name: bosh-cpi-src
   - name: bosh-cpi-release
-  - name: bosh-release
+  - name: bosh-deployment
   - name: stemcell
   - name: bosh-cli
 outputs:
@@ -32,5 +32,3 @@ params:
   google_address_static_director: replace-me
   private_key_user:               replace-me
   private_key_data:               replace-me
-  director_username:              replace-me
-  director_password:              replace-me

--- a/ci/tasks/setup-infrastructure.sh
+++ b/ci/tasks/setup-infrastructure.sh
@@ -14,12 +14,12 @@ check_param google_subnetwork
 check_param google_subnetwork_range
 check_param google_firewall_internal
 check_param google_firewall_external
-check_param google_address_director_ubuntu
-check_param google_address_bats_ubuntu
+check_param google_address_director
+check_param google_address_bats
+check_param google_address_int
 check_param google_target_pool
 check_param google_backend_service 
 check_param google_region_backend_service
-check_param google_address_int_ubuntu
 check_param google_service_account
 
 echo "Creating google json key..."
@@ -34,9 +34,9 @@ gcloud config set compute/zone ${google_zone}
 
 echo "Setting up google infrastructure..."
 gcloud -q iam service-accounts create ${google_service_account}
-gcloud -q compute addresses create ${google_address_director_ubuntu} --region ${google_region}
-gcloud -q compute addresses create ${google_address_bats_ubuntu} --region ${google_region}
-gcloud -q compute addresses create ${google_address_int_ubuntu} --region ${google_region}
+gcloud -q compute addresses create ${google_address_director} --region ${google_region}
+gcloud -q compute addresses create ${google_address_bats} --region ${google_region}
+gcloud -q compute addresses create ${google_address_int} --region ${google_region}
 gcloud -q compute networks create ${google_auto_network}
 gcloud -q compute networks create ${google_network} --mode custom
 gcloud -q compute networks subnets create ${google_subnetwork} --network=${google_network} --range=${google_subnetwork_range}

--- a/ci/tasks/setup-infrastructure.yml
+++ b/ci/tasks/setup-infrastructure.yml
@@ -19,10 +19,10 @@ params:
   google_subnetwork_range:        replace-me
   google_firewall_internal:       replace-me
   google_firewall_external:       replace-me
-  google_address_director_ubuntu: replace-me
-  google_address_bats_ubuntu:     replace-me
+  google_address_director:        replace-me
+  google_address_bats:            replace-me
   google_target_pool:             replace-me
   google_backend_service:         replace-me
   google_region_backend_service:  replace-me
-  google_address_int_ubuntu:      replace-me
+  google_address_int:             replace-me
   google_service_account:         replace-me

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -5,6 +5,7 @@ set -e
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
+creds_file="${PWD}/director-creds/creds.yml"
 deployment_dir="${PWD}/deployment"
 google_json_key=${deployment_dir}/google_key.json
 manifest_filename="director-manifest.yml"
@@ -26,6 +27,7 @@ pushd ${deployment_dir}
       --vars-store=${creds_file} \
       -o bosh-deployment/gcp/cpi.yml \
       -o bosh-deployment/gcp/gcs-blobstore.yml \
+      -o bosh-deployment/external-ip-not-recommended.yml \
       -o ops_local_cpi.yml \
       -o ops_local_stemcell.yml \
       -o ops_add_vcap.yml \
@@ -33,6 +35,7 @@ pushd ${deployment_dir}
       -v internal_cidr=${google_subnetwork_range} \
       -v internal_gw=${google_subnetwork_gw} \
       -v internal_ip=${google_address_static_director} \
+      -v external_ip=${director_ip} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
       -v zone=${google_zone} \

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -35,7 +35,7 @@ pushd ${deployment_dir}
       -v internal_cidr=${google_subnetwork_range} \
       -v internal_gw=${google_subnetwork_gw} \
       -v internal_ip=${google_address_static_director} \
-      -v external_ip=${director_ip} \
+      -v external_ip=${google_address_director_ip} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
       -v zone=${google_zone} \

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -18,23 +18,28 @@ cp ${google_json_key} $HOME/.config/gcloud/application_default_credentials.json
 # Export prefixed variables so they are accessible
 echo "Populating environment with BOSH_ prefixed vars"
 export BOSH_CONFIG=${deployment_dir}/.boshconfig
-export BOSH_director_username=$director_username
-export BOSH_director_password=$director_password
-export BOSH_cpi_release_name=$cpi_release_name
-export BOSH_google_zone=$google_zone
-export BOSH_google_project=$google_project
-export BOSH_google_address_static_director=$google_address_static_director
-export BOSH_director_ip=$director_ip
-export BOSH_google_test_bucket_name=$google_test_bucket_name
-export BOSH_google_network=$google_network
-export BOSH_google_subnetwork_gw=$google_subnetwork_gw
-export BOSH_google_subnetwork=$google_subnetwork
-export BOSH_google_subnetwork_range=$google_subnetwork_range
-export BOSH_google_firewall_internal=$google_firewall_internal
-export BOSH_google_firewall_external=$google_firewall_external
-export BOSH_google_json_key_data=$google_json_key_data
 
 pushd ${deployment_dir}
   echo "Destroying BOSH Director..."
-  ./bosh delete-env ${manifest_filename} --state ${manifest_state_filename} --vars-store ${certs} --vars-env=BOSH
+  ./bosh delete-env bosh-deployment/bosh.yml \
+      --state=${manifest_state_filename} \
+      --vars-store=${creds_file} \
+      -o bosh-deployment/gcp/cpi.yml \
+      -o bosh-deployment/gcp/gcs-blobstore.yml \
+      -o ops_local_cpi.yml \
+      -o ops_local_stemcell.yml \
+      -o ops_add_vcap.yml \
+      -v director_name=micro-google \
+      -v internal_cidr=${google_subnetwork_range} \
+      -v internal_gw=${google_subnetwork_gw} \
+      -v internal_ip=${google_address_static_director} \
+      --var-file gcp_credentials_json=${google_json_key} \
+      -v project_id=${google_project} \
+      -v zone=${google_region} \
+      -v "tags=[${google_firewall_internal}, ${google_firewall_external}]" \
+      -v network=${google_network} \
+      -v subnetwork=${google_subnetwork} \
+      -v bucket_name=${google_test_bucket_name} \
+     --var-file director_gcs_credentials_json=${google_json_key} \
+     --var-file agent_gcs_credentials_json=${google_json_key}
 popd

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -27,7 +27,6 @@ pushd ${deployment_dir}
   ./bosh delete-env bosh-deployment/bosh.yml \
       --state=${manifest_state_filename} \
       --vars-store=${creds_file} \
-      -o bosh-deployment/gcp/cpi.yml \
       -o bosh-deployment/gcp/gcs-blobstore.yml \
       -o bosh-deployment/external-ip-not-recommended.yml \
       -o ops_local_cpi.yml \

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -10,7 +10,9 @@ deployment_dir="${PWD}/deployment"
 google_json_key=${deployment_dir}/google_key.json
 manifest_filename="director-manifest.yml"
 manifest_state_filename="manifest-state.json"
-certs=certs.yml
+infrastructure_metadata="${PWD}/infrastructure/metadata"
+
+read_infrastructure
 
 echo "Creating google json key..."
 mkdir -p $HOME/.config/gcloud/

--- a/ci/tasks/teardown-director.sh
+++ b/ci/tasks/teardown-director.sh
@@ -35,7 +35,7 @@ pushd ${deployment_dir}
       -v internal_ip=${google_address_static_director} \
       --var-file gcp_credentials_json=${google_json_key} \
       -v project_id=${google_project} \
-      -v zone=${google_region} \
+      -v zone=${google_zone} \
       -v "tags=[${google_firewall_internal}, ${google_firewall_external}]" \
       -v network=${google_network} \
       -v subnetwork=${google_subnetwork} \

--- a/ci/tasks/teardown-director.yml
+++ b/ci/tasks/teardown-director.yml
@@ -8,24 +8,12 @@ inputs:
   - name: bosh-cpi-src
   - name: bosh-cli
   - name: deployment
+  - name: infrastructure
+  - name: director-creds
 run:
   path: bosh-cpi-src/ci/tasks/teardown-director.sh
 params:
   BOSH_INIT_LOG_LEVEL: warn
-  google_project:                 replace-me
-  google_region:                  replace-me
-  google_zone:                    replace-me
   google_json_key_data:           replace-me
-  google_test_bucket_name:        replace-me
-  google_network:                 replace-me
-  google_subnetwork:              replace-me
-  google_subnetwork_range:        replace-me
-  google_subnetwork_gw:           replace-me
-  google_firewall_internal:       replace-me
-  google_firewall_external:       replace-me
-  google_address_director:        replace-me
-  google_address_static_director: replace-me
   private_key_user:               replace-me
   private_key_data:               replace-me
-  director_username:              replace-me
-  director_password:              replace-me

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -22,12 +22,10 @@ gcloud config set compute/zone ${google_zone}
 
 gcloud compute instances list --format json | jq -r --arg network ${google_auto_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
   echo "Deleting orphan instance ${instance}..."
-  gcloud -q compute instances delete ${instance} --delete-disks all &
+  gcloud -q compute instances delete ${instance} --delete-disks all
 done
 
 gcloud compute instances list --format json | jq -r --arg network ${google_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
   echo "Deleting orphan instance ${instance}..."
-  gcloud -q compute instances delete ${instance} --delete-disks all &
+  gcloud -q compute instances delete ${instance} --delete-disks all
 done
-
-wait

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -25,5 +25,10 @@ gcloud compute instances list --format json | jq -r --arg network ${google_auto_
   gcloud -q compute instances delete ${instance} --delete-disks all &
 done
 
+gcloud compute instances list --format json | jq -r --arg network ${google_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
+  echo "Deleting orphan instance ${instance}..."
+  gcloud -q compute instances delete ${instance} --delete-disks all &
+done
+
 wait
 set -e

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -5,22 +5,10 @@ set -e
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
-check_param google_project
-check_param google_region
-check_param google_zone
 check_param google_json_key_data
-check_param google_auto_network
-check_param google_target_pool
-check_param google_backend_service
-check_param google_region_backend_service
-check_param google_network
-check_param google_subnetwork
-check_param google_firewall_internal
-check_param google_firewall_external
-check_param google_address_director
-check_param google_address_bats
-check_param google_address_int
-check_param google_service_account
+
+infrastructure_metadata="${PWD}/infrastructure/metadata"
+read_infrastructure
 
 echo "Creating google json key..."
 mkdir -p $HOME/.config/gcloud/
@@ -32,34 +20,9 @@ gcloud config set project ${google_project}
 gcloud config set compute/region ${google_region}
 gcloud config set compute/zone ${google_zone}
 
-echo "Tearing down google infrastructure..."
-set +e
-gcloud -q iam service-accounts delete ${google_service_account}@${google_project}.iam.gserviceaccount.com
-gcloud compute instances list --format json | jq -r --arg network ${google_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
-  echo "Deleting orphan instance ${instance}..."
-  gcloud -q compute instances delete ${instance} --delete-disks all
-done
-
 gcloud compute instances list --format json | jq -r --arg network ${google_auto_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
   echo "Deleting orphan instance ${instance}..."
   gcloud -q compute instances delete ${instance} --delete-disks all
 done
-
-gcloud -q compute firewall-rules delete ${google_firewall_external}
-gcloud -q compute firewall-rules delete ${google_firewall_internal}
-gcloud -q compute networks subnets delete ${google_subnetwork}
-gcloud -q compute networks delete ${google_network}
-gcloud -q compute networks delete ${google_auto_network}
-gcloud -q compute addresses delete ${google_address_director}
-gcloud -q compute addresses delete ${google_address_bats}
-gcloud -q compute addresses delete ${google_address_int}
-gcloud -q compute target-pools delete ${google_target_pool}
-gcloud -q compute backend-services delete ${google_backend_service}
-gcloud -q compute http-health-checks delete ${google_backend_service}
-gcloud -q compute instance-groups unmanaged delete ${google_backend_service}
-gcloud -q compute backend-services delete ${google_region_backend_service} --region ${google_region}
-gcloud -q compute health-checks delete ${google_region_backend_service}
-gcloud -q compute instances delete ${google_region_backend_service} --zone ${google_zone}
-gcloud -q compute instance-groups unmanaged delete ${google_region_backend_service} --zone ${google_zone}
 
 set -e

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -4,9 +4,11 @@ source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
 check_param google_json_key_data
-
-infrastructure_metadata="${PWD}/infrastructure/metadata"
-read_infrastructure
+check_param google_project
+check_param google_region
+check_param google_zone
+check_param google_auto_network
+check_param google_network
 
 echo "Creating google json key..."
 mkdir -p $HOME/.config/gcloud/

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -17,9 +17,9 @@ check_param google_network
 check_param google_subnetwork
 check_param google_firewall_internal
 check_param google_firewall_external
-check_param google_address_director_ubuntu
-check_param google_address_bats_ubuntu
-check_param google_address_int_ubuntu
+check_param google_address_director
+check_param google_address_bats
+check_param google_address_int
 check_param google_service_account
 
 echo "Creating google json key..."
@@ -50,9 +50,9 @@ gcloud -q compute firewall-rules delete ${google_firewall_internal}
 gcloud -q compute networks subnets delete ${google_subnetwork}
 gcloud -q compute networks delete ${google_network}
 gcloud -q compute networks delete ${google_auto_network}
-gcloud -q compute addresses delete ${google_address_director_ubuntu}
-gcloud -q compute addresses delete ${google_address_bats_ubuntu}
-gcloud -q compute addresses delete ${google_address_int_ubuntu}
+gcloud -q compute addresses delete ${google_address_director}
+gcloud -q compute addresses delete ${google_address_bats}
+gcloud -q compute addresses delete ${google_address_int}
 gcloud -q compute target-pools delete ${google_target_pool}
 gcloud -q compute backend-services delete ${google_backend_service}
 gcloud -q compute http-health-checks delete ${google_backend_service}

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -22,7 +22,8 @@ gcloud config set compute/zone ${google_zone}
 
 gcloud compute instances list --format json | jq -r --arg network ${google_auto_network} '.[] | select(.networkInterfaces[].network==$network) | "\(.name) --zone \(.zone)"' | while read instance; do
   echo "Deleting orphan instance ${instance}..."
-  gcloud -q compute instances delete ${instance} --delete-disks all
+  gcloud -q compute instances delete ${instance} --delete-disks all &
 done
 
+wait
 set -e

--- a/ci/tasks/teardown-infrastructure.sh
+++ b/ci/tasks/teardown-infrastructure.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -e
-
 source bosh-cpi-src/ci/tasks/utils.sh
 source /etc/profile.d/chruby-with-ruby-2.1.2.sh
 
@@ -31,4 +29,3 @@ gcloud compute instances list --format json | jq -r --arg network ${google_netwo
 done
 
 wait
-set -e

--- a/ci/tasks/teardown-infrastructure.yml
+++ b/ci/tasks/teardown-infrastructure.yml
@@ -17,9 +17,9 @@ params:
   google_subnetwork:              replace-me
   google_firewall_internal:       replace-me
   google_firewall_external:       replace-me
-  google_address_director_ubuntu: replace-me
-  google_address_bats_ubuntu:     replace-me
-  google_address_int_ubuntu:      replace-me
+  google_address_director:        replace-me
+  google_address_bats:            replace-me
+  google_address_int:             replace-me
   google_service_account:         replace-me
   google_backend_service:         replace-me
   google_region_backend_service:  replace-me

--- a/ci/tasks/teardown-infrastructure.yml
+++ b/ci/tasks/teardown-infrastructure.yml
@@ -6,20 +6,8 @@ image_resource:
     repository: boshcpi/gce-cpi-release
 inputs:
   - name: bosh-cpi-src
+  - name: infrastructure
 run:
   path: bosh-cpi-src/ci/tasks/teardown-infrastructure.sh
 params:
-  google_project:                 replace-me
-  google_region:                  replace-me
-  google_zone:                    replace-me
   google_json_key_data:           replace-me
-  google_network:                 replace-me
-  google_subnetwork:              replace-me
-  google_firewall_internal:       replace-me
-  google_firewall_external:       replace-me
-  google_address_director:        replace-me
-  google_address_bats:            replace-me
-  google_address_int:             replace-me
-  google_service_account:         replace-me
-  google_backend_service:         replace-me
-  google_region_backend_service:  replace-me

--- a/ci/tasks/teardown-infrastructure.yml
+++ b/ci/tasks/teardown-infrastructure.yml
@@ -6,7 +6,6 @@ image_resource:
     repository: boshcpi/gce-cpi-release
 inputs:
   - name: bosh-cpi-src
-  - name: infrastructure
 run:
   path: bosh-cpi-src/ci/tasks/teardown-infrastructure.sh
 params:

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -69,8 +69,8 @@ function read_infrastructure {
   export google_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_backend_service)
   export google_region_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_region_backend_service)
   export google_target_pool=$(cat ${infrastructure_metadata} | jq -r .google_target_pool)
-  export google_address_director=$(cat ${infrastructure_metadata} | jq -r .google_address_director)
-  export google_address_bats=$(cat ${infrastructure_metadata} | jq -r .google_address_bats)
-  export google_address_int=$(cat ${infrastructure_metadata} | jq -r .google_address_int)
+  export google_address_director_ip=$(cat ${infrastructure_metadata} | jq -r .google_address_director_ip)
+  export google_address_bats_ip=$(cat ${infrastructure_metadata} | jq -r .google_address_bats_ip)
+  export google_address_int_ip=$(cat ${infrastructure_metadata} | jq -r .google_address_int_ip)
   export google_service_account=$(cat ${infrastructure_metadata} | jq -r .google_service_account)
 }

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -69,8 +69,8 @@ function read_infrastructure {
   export google_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_backend_service)
   export google_region_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_region_backend_service)
   export google_target_pool=$(cat ${infrastructure_metadata} | jq -r .google_target_pool)
-  export google_address_director_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_director_ubuntu)
-  export google_address_bats_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_bats_ubuntu)
-  export google_address_int_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_int_ubuntu)
+  export google_address_director=$(cat ${infrastructure_metadata} | jq -r .google_address_director)
+  export google_address_bats=$(cat ${infrastructure_metadata} | jq -r .google_address_bats)
+  export google_address_int=$(cat ${infrastructure_metadata} | jq -r .google_address_int)
   export google_service_account=$(cat ${infrastructure_metadata} | jq -r .google_service_account)
 }

--- a/ci/tasks/utils.sh
+++ b/ci/tasks/utils.sh
@@ -3,7 +3,7 @@
 check_param() {
   local name=$1
   local value=$(eval echo '$'$name)
-  if [ "$value" == 'replace-me' ]; then
+  if [ "$value" == 'replace-me' ] || [ "$value" == '' ]; then
     echo "environment variable $name must be set"
     exit 1
   fi
@@ -53,4 +53,24 @@ function check_go_version {
     echo "Go version is incorrect. Required version: $release_go_version"
     exit 1
   fi
+}
+
+function read_infrastructure {
+  echo "Reading infrastructure values..."
+  export google_project=$(cat ${infrastructure_metadata} | jq -r .google_project)
+  export google_region=$(cat ${infrastructure_metadata} | jq -r .google_region)
+  export google_zone=$(cat ${infrastructure_metadata} | jq -r .google_zone)
+  export google_json_key_data=$(cat ${infrastructure_metadata} | jq -r .google_json_key_data)
+  export google_auto_network=$(cat ${infrastructure_metadata} | jq -r .google_auto_network)
+  export google_network=$(cat ${infrastructure_metadata} | jq -r .google_network)
+  export google_subnetwork=$(cat ${infrastructure_metadata} | jq -r .google_subnetwork)
+  export google_firewall_internal=$(cat ${infrastructure_metadata} | jq -r .google_firewall_internal)
+  export google_firewall_external=$(cat ${infrastructure_metadata} | jq -r .google_firewall_external)
+  export google_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_backend_service)
+  export google_region_backend_service=$(cat ${infrastructure_metadata} | jq -r .google_region_backend_service)
+  export google_target_pool=$(cat ${infrastructure_metadata} | jq -r .google_target_pool)
+  export google_address_director_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_director_ubuntu)
+  export google_address_bats_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_bats_ubuntu)
+  export google_address_int_ubuntu=$(cat ${infrastructure_metadata} | jq -r .google_address_int_ubuntu)
+  export google_service_account=$(cat ${infrastructure_metadata} | jq -r .google_service_account)
 }


### PR DESCRIPTION
* Use [bosh-deployment](https://github.com/cloudfoundry/bosh-deployment) to deploy the director. It ensures we don't break our deployment when testing the CPI against a new version of [bosh](https://github.com/cloudfoundry/bosh) due to changes in manifest spec. The repo is used to generate a manifest based off of a reference that should be up to date with the latest release version. It also speeds up deployment times (from 20 mins -> 6mins) by using a precompiled release of BOSH.
* Use terraform to create/destroy infrastructure needed for the integration tests and BATS. This makes it much easier to maintain and speeds up deployment times (from 5min->~2mins)
* Use BOSH2 throughout deployment pipeline. The legacy CLI is used to build the bosh-release.
* Specify a BATS config file instead of generating a manifest. This ensures changes in BATS internals do not break our CI pipeline... the motivator to this work. 

This PR will be squashed because it's full of noise! 