### PR TITLE
stemcell_delete: Ignore missing stemcells

### DIFF
--- a/src/bosh-google-cpi/google/image_service/google_image_service_delete.go
+++ b/src/bosh-google-cpi/google/image_service/google_image_service_delete.go
@@ -10,7 +10,8 @@ func (i GoogleImageService) Delete(id string) error {
 		return err
 	}
 	if !found {
-		return bosherr.WrapErrorf(err, "Google Image '%s' does not exists", id)
+		// consider it a success, the image is gone
+		return nil
 	}
 
 	if image.Status != googleImageReadyStatus && image.Status != googleImageFailedStatus {

--- a/src/bosh-google-cpi/integration/stemcell_test.go
+++ b/src/bosh-google-cpi/integration/stemcell_test.go
@@ -34,5 +34,18 @@ var _ = Describe("Stemcell", func() {
 		Expect(response.Error).To(BeNil())
 		Expect(response.Result).To(BeNil())
 	})
+
+	It("quietly ignores missing stemcells", func() {
+		By("deleting the stemcell")
+		request := `{
+         "method": "delete_stemcell",
+         "arguments": ["stemcell-ab5f5573-62d5-4f72-6620-3ab8f1aed3cf"]
+		}`
+
+		response, err := execCPI(request)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(response.Error).To(BeNil())
+		Expect(response.Result).To(BeNil())
+	})
 	//TODO: Add heavy stemcell test
 })


### PR DESCRIPTION
If the stemcell has been deleted out of band then bosh delete-env will
never succeed. This change will be silent when asked to delete a missing
stemcell. It will still propogate actual errors (eg can't fetch the
stemcell due to permissions).

Fixes #162