### PR TITLE
Support Extended Memory Custom Instances

### DIFF
--- a/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link.go
+++ b/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link.go
@@ -7,5 +7,10 @@ import (
 )
 
 func (m GoogleMachineTypeService) CustomLink(cpu int, ram int, zone string) string {
-	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/machineTypes/custom-%d-%d", m.project, util.ResourceSplitter(zone), cpu, ram)
+	suffix := ""
+	extendedThreshold := int(float64(cpu*1024) * 6.5)
+	if ram > extendedThreshold {
+		suffix = "-ext"
+	}
+	return fmt.Sprintf("https://www.googleapis.com/compute/v1/projects/%s/zones/%s/machineTypes/custom-%d-%d%s", m.project, util.ResourceSplitter(zone), cpu, ram, suffix)
 }

--- a/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link_test.go
+++ b/src/bosh-google-cpi/google/machine_type_service/google_machine_type_service_custom_link_test.go
@@ -1,0 +1,24 @@
+package machinetype_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	. "bosh-google-cpi/google/machine_type_service"
+)
+
+var _ = Describe("GoogleMachineTypeServiceCustomLink", func() {
+	var subject GoogleMachineTypeService
+
+	BeforeEach(func() {
+		subject = NewGoogleMachineTypeService("foo", nil, nil)
+	})
+
+	It("provides a normal sized machine type link", func() {
+		Expect(subject.CustomLink(2, 2048, "us-east1-d")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-2-2048"))
+	})
+
+	It("provides an extended machine type link", func() {
+		Expect(subject.CustomLink(4, 26880, "us-east1-d")).To(Equal("https://www.googleapis.com/compute/v1/projects/foo/zones/us-east1-d/machineTypes/custom-4-26880-ext"))
+	})
+})


### PR DESCRIPTION
When creating a custom machine type with more than 6.5GB per core it is
necessary to supply the -ext suffix[1]

[1] https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#determining_if_you_need_extended_memory