### PR TITLE
Implement calculate_vm_cloud_properties action

### DIFF
--- a/src/bosh-google-cpi/README.md
+++ b/src/bosh-google-cpi/README.md
@@ -25,40 +25,34 @@ Create a configuration file:
 
 ```
 {
-  "google": {
-    "project": "my-gce-project",
-    "json_key": "{\"private_key_id\": \"...\"}",
-    "default_root_disk_size_gb": 20,
-    "default_root_disk_type": ""
-  },
-  "actions": {
-    "agent": {
-      "mbus": "https://mbus:mbus@0.0.0.0:6868",
-      "ntp": [
-        "169.254.169.254"
-      ],
-      "blobstore": {
-        "type": "local",
-        "options": {}
-      }
-    },
-    "registry": {
-      "protocol": "http",
-      "host": "127.0.0.1",
-      "port": 25777,
-      "username": "admin",
-      "password": "admin",
-      "tls": {
-        "_comment": "TLS options only apply when using HTTPS protocol",
-        "insecure_skip_verify": true,
-        "certfile": "/path/to/public.pem",
-        "keyfile": "/path/to/private.pem",
-        "cacertfile": "/path/to/ca.pem"
+  "cloud": {
+    "plugin": "google",
+    "properties": {
+      "google": {
+        "project": "my-gce-project",
+        "json_key": "{\"private_key_id\": \"...\"}",
+        "default_root_disk_size_gb": 20,
+        "default_root_disk_type": ""
+      },
+      "agent": {
+        "mbus": "https:\/\/mbus:mbus@0.0.0.0:6868",
+        "ntp": [
+          "169.254.169.254"
+        ],
+        "blobstore": {
+          "provider": "local",
+          "options": {
+          }
+        }
+      },
+      "registry": {
+        "use_gce_metadata": true
       }
     }
   }
 }
 ```
+
 
 | Option                                    | Required   | Type          | Description
 |:------------------------------------------|:----------:|:------------- |:-----------

--- a/src/bosh-google-cpi/action/calculate_vm_cloud_properties.go
+++ b/src/bosh-google-cpi/action/calculate_vm_cloud_properties.go
@@ -1,0 +1,55 @@
+package action
+
+import (
+	"strings"
+
+	bosherr "github.com/cloudfoundry/bosh-utils/errors"
+)
+
+type DesiredVMSpec struct {
+	CPU               int `json:"cpu"`
+	RAM               int `json:"ram"`
+	EphemeralDiskSize int `json:"ephemeral_disk_size"`
+}
+
+type CalculateVMCloudProperties struct{}
+
+func NewCalculateVMCloudProperties() CalculateVMCloudProperties {
+	return CalculateVMCloudProperties{}
+}
+
+const (
+	gb                = 1024
+	minMemoryPerCPU   = 0.9 * gb
+	memoryGranularity = 256
+)
+
+const (
+	NoCPUErr       = "CPU must be greater than 0"
+	RamPerCPUErr   = "RAM per CPU must be at least 922 MB"
+	RamMultipleErr = "RAM must be specified as a multiple of 256 MB"
+)
+
+func (CalculateVMCloudProperties) Run(desired DesiredVMSpec) (VMCloudProperties, error) {
+	var errs []string
+	if desired.CPU <= 0 {
+		errs = append(errs, NoCPUErr)
+	}
+	minRam := float64(desired.CPU) * float64(minMemoryPerCPU)
+	if float64(desired.RAM) < minRam {
+		errs = append(errs, RamPerCPUErr)
+	}
+	if desired.RAM%memoryGranularity != 0 {
+		errs = append(errs, RamMultipleErr)
+	}
+
+	if len(errs) != 0 {
+		return VMCloudProperties{}, bosherr.Errorf("invalid desired instance specification: %s", strings.Join(errs, ", "))
+	}
+
+	return VMCloudProperties{
+		CPU:            desired.CPU,
+		RAM:            desired.RAM,
+		RootDiskSizeGb: desired.EphemeralDiskSize,
+	}, nil
+}

--- a/src/bosh-google-cpi/action/calculate_vm_cloud_properties_test.go
+++ b/src/bosh-google-cpi/action/calculate_vm_cloud_properties_test.go
@@ -1,0 +1,50 @@
+package action_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/ginkgo/extensions/table"
+	. "github.com/onsi/gomega"
+
+	. "bosh-google-cpi/action"
+
+	. "github.com/onsi/gomega/gstruct"
+)
+
+var _ = Describe("CalculateVMCloudProperties", func() {
+	var subject CalculateVMCloudProperties
+
+	BeforeEach(func() {
+		subject = NewCalculateVMCloudProperties()
+	})
+
+	DescribeTable("valid machine specification return matching specs", func(cpu, ram, disk int) {
+		res, err := subject.Run(DesiredVMSpec{CPU: cpu, RAM: ram, EphemeralDiskSize: disk})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(res).To(MatchFields(IgnoreExtras, Fields{
+			"CPU":            Equal(cpu),
+			"RAM":            Equal(ram),
+			"RootDiskSizeGb": Equal(disk),
+		}))
+	},
+		Entry("1 core, 1024 memory, 1024 disk", 1, 1024, 1024),
+		Entry("2 core, 2048 memory, 1024 disk", 2, 2048, 1024),
+		Entry("4 core, 6144 memory, 1024 disk", 4, 6144, 1024),
+	)
+	DescribeTable("invalid machine specification returns error", func(cpu, ram, disk int, errs []string) {
+		_, err := subject.Run(DesiredVMSpec{CPU: cpu, RAM: ram, EphemeralDiskSize: disk})
+		Expect(err).To(HaveOccurred())
+
+		for _, expected := range errs {
+			Expect(err.Error()).To(ContainSubstring(expected))
+		}
+	},
+		Entry("no cores", 0, 1024, 1024, []string{NoCPUErr}),
+		Entry("no memory", 1, 0, 1024, []string{RamPerCPUErr}),
+		Entry("bad memory multiple", 1, 922, 1024, []string{RamMultipleErr}),
+		Entry("too little memory, bad multiple", 2, 1843, 1024, []string{RamPerCPUErr, RamMultipleErr}),
+	)
+	Context("valid machine specifications", func() {
+
+	})
+})

--- a/src/bosh-google-cpi/action/concrete_factory.go
+++ b/src/bosh-google-cpi/action/concrete_factory.go
@@ -188,6 +188,7 @@ func NewConcreteFactory(
 			// Others:
 			"info": NewInfo(),
 			"ping": NewPing(),
+			"calculate_vm_cloud_properties": NewCalculateVMCloudProperties(),
 
 			// Not implemented:
 			// current_vm_id

--- a/src/bosh-google-cpi/integration/calculate_vm_cloud_properties_test.go
+++ b/src/bosh-google-cpi/integration/calculate_vm_cloud_properties_test.go
@@ -1,0 +1,21 @@
+package integration
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Misc", func() {
+	Describe("calculate_vm_cloud_properties", func() {
+		FIt("provides a basic match", func() {
+			result := assertSucceedsWithResult(`{
+				"method": "calculate_vm_cloud_properties",
+				"arguments": [{"cpu":1,"ram":1024,"ephemeral_disk_size":1024}]
+			}`).(map[string]interface{})
+
+			Expect(result).To(HaveKey("cpu"))
+			Expect(result).To(HaveKey("ram"))
+			Expect(result).To(HaveKey("root_disk_size_db"))
+		})
+	})
+})


### PR DESCRIPTION
Implement the spec[1] of the new action. This implementation validates
the minimum requirements for a custom machine type[2]. It does not validate
maximum requirements because they depend on CPU architecture, region,
and avalibility. This limited validation should serve as a good starting
point but we can evaluate in the future if this needs to be expanded.

Fixes #253 

[1] http://bosh.io/docs/cpi-api-v1#calculate-vm-cloud-properties
[2] https://cloud.google.com/compute/docs/instances/creating-instance-with-custom-machine-type#specifications