### PR TITLE
docs/bosh, concourse: image update, terraform syntax fix

### DIFF
--- a/docs/bosh/main.tf
+++ b/docs/bosh/main.tf
@@ -1,7 +1,6 @@
-// Easier maintenance for updating GCE image string
 variable "latest_ubuntu" {
     type = "string"
-    default = "ubuntu-1404-trusty-v20170505"
+    default = "ubuntu-1404-trusty-v20180122"
 }
 
 variable "project_id" {

--- a/docs/concourse/main.tf
+++ b/docs/concourse/main.tf
@@ -84,8 +84,10 @@ resource "google_compute_instance" "bosh-bastion" {
 
   tags = ["bosh-bastion", "bosh-internal"]
 
-  disk {
-    image = "ubuntu-1404-trusty-v20160627"
+  boot_disk {
+   initialize_params {
+     image = "ubuntu-1404-trusty-v20180122"
+   }
   }
 
   network_interface {


### PR DESCRIPTION
- terraform now requires a boot_disk param instead of disk
- update ubuntu image version

fixes #259